### PR TITLE
Add Features section to Discover page

### DIFF
--- a/src/pages/Newsletter.tsx
+++ b/src/pages/Newsletter.tsx
@@ -674,13 +674,13 @@ const FeaturesVisualIcon = styled.div<{ $bg: string }>`
 const FeaturesGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
+  gap: 0.75rem;
   padding: 1.25rem 0 1rem;
 
-  @media (max-width: 860px) {
+  @media (max-width: 540px) {
     grid-template-columns: 1fr 1fr;
   }
-  @media (max-width: 540px) {
+  @media (max-width: 360px) {
     grid-template-columns: 1fr;
   }
 `;
@@ -688,11 +688,11 @@ const FeaturesGrid = styled.div`
 const FeatureCard = styled.div`
   background: ${palette.colors.gray[800]};
   border: 1px solid ${palette.colors.gray[700]};
-  border-radius: ${palette.borderRadius.xLarge};
-  padding: 20px;
+  border-radius: ${palette.borderRadius.large};
+  padding: 14px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 7px;
   transition: border-color 0.3s, transform 0.3s;
 
   &:hover {
@@ -702,20 +702,20 @@ const FeatureCard = styled.div`
 `;
 
 const FeatureIconBox = styled.div<{ $bg: string }>`
-  width: 52px;
-  height: 52px;
-  border-radius: 12px;
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
   background: ${({ $bg }) => $bg};
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 24px;
+  font-size: 17px;
   flex-shrink: 0;
 `;
 
 const FeatureName = styled.h3`
   font-family: ${palette.typography.fontFamily.inter};
-  font-size: 1rem;
+  font-size: 0.875rem;
   font-weight: ${palette.typography.fontWeight.semibold};
   color: ${palette.colors.gray[100]};
   margin: 0;
@@ -724,16 +724,16 @@ const FeatureName = styled.h3`
 
 const FeatureDesc = styled.p`
   font-family: ${palette.typography.fontFamily.inter};
-  font-size: ${palette.typography.fontSize.sm};
+  font-size: ${palette.typography.fontSize.xs};
   color: ${palette.colors.gray[400]};
-  line-height: 1.6;
+  line-height: 1.55;
   margin: 0;
   flex: 1;
 `;
 
 const FeatureBadge = styled.span`
   display: inline-block;
-  padding: 4px 10px;
+  padding: 3px 8px;
   border-radius: 9999px;
   background: ${palette.colors.gray[700]};
   color: ${palette.colors.gray[500]};


### PR DESCRIPTION
Closes #114

## Summary

- New **FEATURES** expandable section on the Discover page, positioned after HOW TO USE TILER
- Hero: "FEATURES" badge · "Everything Tiler can do." title · sub-copy · 3×3 mini icon grid visual (9 coloured emoji boxes) · chevron to expand
- **14 feature cards** in a 3-column grid, each with a coloured icon box (36px), title, description, and category badge:

  | Feature | Badge |
  |---|---|
  | Adaptive Tiles | Core feature |
  | AI scheduling assistant | Core feature |
  | Chat scheduling | Core feature |
  | Natural language input | Core feature |
  | Auto travel buffers | Unique to Tiler |
  | Auto locations | Unique to Tiler |
  | Time restrictions | Preferences |
  | Adaptive rescheduling | Core feature |
  | Calendar integration | Integration |
  | Cross-platform sync | Platform |
  | Habit scheduling | Wellness |
  | Defer & reschedule | Core feature |
  | Smart notifications | Real-time |
  | TileShare | Collaboration |

- Cards sized for 3-column layout at all viewport widths above 540px (drops to 2-col below)
- New styled components: `FeaturesVisual`, `FeaturesVisualRow`, `FeaturesVisualIcon`, `FeaturesGrid`, `FeatureCard`, `FeatureIconBox`, `FeatureName`, `FeatureDesc`, `FeatureBadge`

## Test plan

- [ ] Navigate to `/newsletter` → Discover tab
- [ ] Scroll to the **Features** section — confirm hero shows badge, title, sub-copy, and 3×3 icon grid
- [ ] Click to expand — confirm all 14 feature cards render in 3 columns
- [ ] Each card has a coloured icon box, bold title, description text, and category badge
- [ ] Hover on a card shows brand-red border highlight and slight lift (`translateY(-2px)`)
- [ ] Resize viewport below 540px — grid drops to 2 columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)