### PR TITLE
Remove waitlist email section from homepage

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,7 +5,6 @@ import TileCardSection from '../components/home/tile_card_section';
 import CalendarIntegrationSection from '../components/home/integration_section';
 import HeroSection from '../components/home/hero_section';
 import VideoIframeSection from '../components/home/video_iframe_section';
-import Waitlist from '../components/home/waitlist_input';
 import AppDownloadSection from '../components/home/app_download_section';
 import FAQ from '../components/home/faq_section';
 import DemoExplainerSection from '../components/home/demo_explainer_section';
@@ -63,7 +62,6 @@ const Home: React.FC = () => {
 			<TileCardSection />
 			<CalendarIntegrationSection />
 			<FAQ />
-			<Waitlist />
 			<AppDownloadSection />
 		</>
 	);


### PR DESCRIPTION
Closes #118

## Summary

Removes the standalone waitlist email input section from the homepage.

- Removed `<Waitlist />` JSX from `Home.tsx`
- Removed `import Waitlist from '../components/home/waitlist_input'`
- `waitlist_input.tsx` component file left intact (not deleted)
- `waitlistSignUp` URL param + scroll behaviour in `VideoIframeSection` left intact (separate concern)

## Test plan

- [ ] Navigate to the homepage — confirm no email input field or "Join Waitlist" CTA appears
- [ ] Page layout flows cleanly without the waitlist section
- [ ] No console errors related to missing imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)