### PR TITLE
Fix mobile hero media and expand arrow layout

### DIFF
--- a/src/pages/Newsletter.tsx
+++ b/src/pages/Newsletter.tsx
@@ -291,6 +291,13 @@ const ExpandableHeaderRight = styled.div`
   align-items: center;
   gap: 1rem;
   flex-shrink: 0;
+
+  @media (max-width: 640px) {
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    gap: 0.75rem;
+  }
 `;
 
 const chevronBounce = css`


### PR DESCRIPTION
## Summary
- Center the animated hero visual in each expandable section on mobile viewports
- Place the expand/collapse chevron arrow centered below the hero media instead of floating to the right

Single CSS change to `ExpandableHeaderRight` — adds a `@media (max-width: 640px)` rule that switches to `flex-direction: column` with centered alignment.

## Test plan
- [ ] Open `/newsletter` on mobile (≤640px viewport)
- [ ] Verify all 4 section hero visuals (What Is Tiler, Set Up Tiler, How To Use Tiler, Features) are centered
- [ ] Verify chevron arrows are centered below each hero visual
- [ ] Verify desktop layout (>640px) is unchanged — visual and chevron remain side-by-side on the right

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)