### PR TITLE
Add Features section to Discover page

### DIFF
--- a/src/components/discover/FeaturesSection.tsx
+++ b/src/components/discover/FeaturesSection.tsx
@@ -1,0 +1,228 @@
+import React, { useState, useMemo } from 'react';
+import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
+import palette from '@/core/theme/palette';
+import {
+  ExpandableWrapper,
+  ExpandableSection,
+  ExpandableHeader,
+  ExpandableTextSide,
+  SectionBadge,
+  SectionTitle,
+  SectionSummary,
+  ExpandableHeaderRight,
+  Chevron,
+  ExpandableBody,
+  ExpandableBodyInner,
+} from './shared';
+
+// ─── Features Visual (header) ────────────────────────────────────────────────
+
+const FeaturesVisual = styled.div`
+  width: 160px;
+  height: 120px;
+  border-radius: ${palette.borderRadius.medium};
+  background: ${palette.colors.gray[800]};
+  border: 1px solid ${palette.colors.gray[700]};
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+
+  @media (max-width: 640px) {
+    width: 100%;
+    height: auto;
+  }
+`;
+
+const FeaturesVisualRow = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+`;
+
+const FeaturesVisualIcon = styled.div<{ $bg: string }>`
+  width: 30px;
+  height: 30px;
+  border-radius: 7px;
+  background: ${({ $bg }) => $bg};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  flex-shrink: 0;
+`;
+
+// ─── Features Grid ───────────────────────────────────────────────────────────
+
+const FeaturesGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+  padding: 1.25rem 0 1rem;
+
+  @media (max-width: 540px) {
+    grid-template-columns: 1fr 1fr;
+  }
+  @media (max-width: 360px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const FeatureCard = styled.div`
+  background: ${palette.colors.gray[800]};
+  border: 1px solid ${palette.colors.gray[700]};
+  border-radius: ${palette.borderRadius.large};
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  transition: border-color 0.3s, transform 0.3s;
+
+  &:hover {
+    border-color: ${palette.colors.brand[500]}40;
+    transform: translateY(-2px);
+  }
+`;
+
+const FeatureIconBox = styled.div<{ $bg: string }>`
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
+  background: ${({ $bg }) => $bg};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 17px;
+  flex-shrink: 0;
+`;
+
+const FeatureName = styled.h3`
+  font-family: ${palette.typography.fontFamily.inter};
+  font-size: 0.875rem;
+  font-weight: ${palette.typography.fontWeight.semibold};
+  color: ${palette.colors.gray[100]};
+  margin: 0;
+  line-height: 1.3;
+`;
+
+const FeatureDesc = styled.p`
+  font-family: ${palette.typography.fontFamily.inter};
+  font-size: ${palette.typography.fontSize.xs};
+  color: ${palette.colors.gray[400]};
+  line-height: 1.55;
+  margin: 0;
+  flex: 1;
+`;
+
+const FeatureBadge = styled.span`
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 9999px;
+  background: ${palette.colors.gray[700]};
+  color: ${palette.colors.gray[500]};
+  font-family: ${palette.typography.fontFamily.inter};
+  font-size: ${palette.typography.fontSize.xs};
+  align-self: flex-start;
+  margin-top: 2px;
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+interface FeatureItem {
+  emoji: string;
+  iconBg: string;
+  nameKey: string;
+  descKey: string;
+  badgeKey: string;
+}
+
+const FEATURE_ITEMS: FeatureItem[] = [
+  { emoji: '🧩', iconBg: '#1A2E3A', nameKey: 'adaptiveTiles', descKey: 'adaptiveTiles', badgeKey: 'adaptiveTiles' },
+  { emoji: '🤖', iconBg: '#3D1C2A', nameKey: 'aiScheduling', descKey: 'aiScheduling', badgeKey: 'aiScheduling' },
+  { emoji: '💬', iconBg: '#1A2840', nameKey: 'chatScheduling', descKey: 'chatScheduling', badgeKey: 'chatScheduling' },
+  { emoji: '🗣️', iconBg: '#4A1A2A', nameKey: 'naturalLanguage', descKey: 'naturalLanguage', badgeKey: 'naturalLanguage' },
+  { emoji: '🚗', iconBg: '#1A3320', nameKey: 'autoTravel', descKey: 'autoTravel', badgeKey: 'autoTravel' },
+  { emoji: '📍', iconBg: '#1A2E3A', nameKey: 'autoLocations', descKey: 'autoLocations', badgeKey: 'autoLocations' },
+  { emoji: '⏰', iconBg: '#2A1A3A', nameKey: 'timeRestrictions', descKey: 'timeRestrictions', badgeKey: 'timeRestrictions' },
+  { emoji: '🔄', iconBg: '#3D1C2A', nameKey: 'adaptiveRescheduling', descKey: 'adaptiveRescheduling', badgeKey: 'adaptiveRescheduling' },
+  { emoji: '📅', iconBg: '#1A2040', nameKey: 'calendarIntegration', descKey: 'calendarIntegration', badgeKey: 'calendarIntegration' },
+  { emoji: '📱', iconBg: '#1A3320', nameKey: 'crossPlatform', descKey: 'crossPlatform', badgeKey: 'crossPlatform' },
+  { emoji: '🎯', iconBg: '#1A3A20', nameKey: 'habitScheduling', descKey: 'habitScheduling', badgeKey: 'habitScheduling' },
+  { emoji: '↩️', iconBg: '#3D1C2A', nameKey: 'deferReschedule', descKey: 'deferReschedule', badgeKey: 'deferReschedule' },
+  { emoji: '🔔', iconBg: '#1A2040', nameKey: 'smartNotifications', descKey: 'smartNotifications', badgeKey: 'smartNotifications' },
+  { emoji: '👥', iconBg: '#1A2E3A', nameKey: 'tileShare', descKey: 'tileShare', badgeKey: 'tileShare' },
+];
+
+const FeaturesSection: React.FC = () => {
+  const { t } = useTranslation();
+  const [featuresOpen, setFeaturesOpen] = useState(false);
+
+  const features = useMemo(
+    () =>
+      FEATURE_ITEMS.map((item) => ({
+        ...item,
+        name: t(`discover.features.items.${item.nameKey}.name`),
+        desc: t(`discover.features.items.${item.descKey}.desc`),
+        badge: t(`discover.features.items.${item.badgeKey}.badge`),
+      })),
+    [t],
+  );
+
+  return (
+    <ExpandableWrapper>
+      <ExpandableSection>
+        <ExpandableHeader
+          $open={featuresOpen}
+          onClick={() => setFeaturesOpen((o) => !o)}
+        >
+          <ExpandableTextSide>
+            <SectionBadge>{t('discover.features.badge')}</SectionBadge>
+            <SectionTitle>{t('discover.features.title')}</SectionTitle>
+            <SectionSummary>{t('discover.features.summary')}</SectionSummary>
+          </ExpandableTextSide>
+
+          <ExpandableHeaderRight>
+            <FeaturesVisual>
+              <FeaturesVisualRow>
+                <FeaturesVisualIcon $bg="#1A2E3A">🧩</FeaturesVisualIcon>
+                <FeaturesVisualIcon $bg="#3D1C2A">🤖</FeaturesVisualIcon>
+                <FeaturesVisualIcon $bg="#1A2840">💬</FeaturesVisualIcon>
+              </FeaturesVisualRow>
+              <FeaturesVisualRow>
+                <FeaturesVisualIcon $bg="#4A1A2A">🗣️</FeaturesVisualIcon>
+                <FeaturesVisualIcon $bg="#1A3320">🚗</FeaturesVisualIcon>
+                <FeaturesVisualIcon $bg="#1A2E3A">📍</FeaturesVisualIcon>
+              </FeaturesVisualRow>
+              <FeaturesVisualRow>
+                <FeaturesVisualIcon $bg="#3D1C2A">🔄</FeaturesVisualIcon>
+                <FeaturesVisualIcon $bg="#1A2040">📅</FeaturesVisualIcon>
+                <FeaturesVisualIcon $bg="#1A2E3A">👥</FeaturesVisualIcon>
+              </FeaturesVisualRow>
+            </FeaturesVisual>
+            <Chevron $open={featuresOpen}>&#9660;</Chevron>
+          </ExpandableHeaderRight>
+        </ExpandableHeader>
+
+        <ExpandableBody $open={featuresOpen}>
+          <ExpandableBodyInner>
+            <FeaturesGrid>
+              {features.map((feature) => (
+                <FeatureCard key={feature.nameKey}>
+                  <FeatureIconBox $bg={feature.iconBg}>{feature.emoji}</FeatureIconBox>
+                  <FeatureName>{feature.name}</FeatureName>
+                  <FeatureDesc>{feature.desc}</FeatureDesc>
+                  <FeatureBadge>{feature.badge}</FeatureBadge>
+                </FeatureCard>
+              ))}
+            </FeaturesGrid>
+          </ExpandableBodyInner>
+        </ExpandableBody>
+      </ExpandableSection>
+    </ExpandableWrapper>
+  );
+};
+
+export default FeaturesSection;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1025,6 +1025,83 @@
 			"badge": "Navigate Tiler",
 			"title": "Here\u2019s Where Everything Lives",
 			"subtitle": "Explore the moments where your day finally makes sense. Find your way around the app. Find things to try in-app."
+		},
+		"features": {
+			"badge": "Features",
+			"title": "Everything Tiler can do.",
+			"summary": "Every feature is built around one principle: your schedule should work for you, not the other way around.",
+			"items": {
+				"adaptiveTiles": {
+					"name": "Adaptive Tiles",
+					"desc": "The core unit of Tiler. Each tile is a task, event, or habit with a duration \u2014 Tiler schedules them intelligently and moves them when your day changes.",
+					"badge": "Core feature"
+				},
+				"aiScheduling": {
+					"name": "AI scheduling assistant",
+					"desc": "Tiler asks clarifying questions, proposes the best available time, and builds a complete schedule including dependencies \u2014 always with your approval first.",
+					"badge": "Core feature"
+				},
+				"chatScheduling": {
+					"name": "Chat scheduling",
+					"desc": "Tell Tiler what you need through a natural chat interface. It understands your intent and proposes a plan without you filling in a single form.",
+					"badge": "Core feature"
+				},
+				"naturalLanguage": {
+					"name": "Natural language input",
+					"desc": "Describe tasks in plain English \u2014 no forms, no dropdowns. Tiler understands context, urgency, duration, and location from how you naturally talk.",
+					"badge": "Core feature"
+				},
+				"autoTravel": {
+					"name": "Auto travel buffers",
+					"desc": "Tiler automatically inserts realistic travel time between location-based tiles based on your actual distance and transit options. Back-to-back never means late.",
+					"badge": "Unique to Tiler"
+				},
+				"autoLocations": {
+					"name": "Auto locations",
+					"desc": "Link locations to tiles once and Tiler remembers. Every time that task appears, travel time is calculated automatically from wherever you are.",
+					"badge": "Unique to Tiler"
+				},
+				"timeRestrictions": {
+					"name": "Time restrictions",
+					"desc": "Set the hours you\u2019re available and Tiler only schedules within those bounds. Your personal time stays yours \u2014 no task bleeds into off-hours unless you allow it.",
+					"badge": "Preferences"
+				},
+				"adaptiveRescheduling": {
+					"name": "Adaptive rescheduling",
+					"desc": "When a meeting runs long or a task gets missed, Tiler detects the ripple across your whole day and proposes fixes \u2014 instantly, with your approval before changing anything.",
+					"badge": "Core feature"
+				},
+				"calendarIntegration": {
+					"name": "Calendar integration",
+					"desc": "Connect Google Calendar or Outlook. Tiler reads your existing events and schedules all new tiles around them \u2014 no double bookings, ever. Supports multiple calendars.",
+					"badge": "Integration"
+				},
+				"crossPlatform": {
+					"name": "Cross-platform sync",
+					"desc": "Web, iOS, and Android all stay in real-time sync. Start a task on your laptop and check in on your phone without missing a beat. One schedule, everywhere.",
+					"badge": "Platform"
+				},
+				"habitScheduling": {
+					"name": "Habit scheduling",
+					"desc": "Add recurring habits and Tiler auto-fits them around your day \u2014 keeping you consistent with your routines without you having to think about it each morning.",
+					"badge": "Wellness"
+				},
+				"deferReschedule": {
+					"name": "Defer & reschedule",
+					"desc": "Missed a tile? Tiler\u2019s Defer feature instantly finds the next best slot and reschedules with one tap. Never lose a task \u2014 just push it forward intelligently.",
+					"badge": "Core feature"
+				},
+				"smartNotifications": {
+					"name": "Smart notifications",
+					"desc": "Get alerted when it\u2019s time to leave for your next tile \u2014 with live transit updates if your route changes. Never miss a departure time because you lost track of the clock.",
+					"badge": "Real-time"
+				},
+				"tileShare": {
+					"name": "TileShare",
+					"desc": "Share tiles with family or teammates. Assign who handles what. Track completion. Everyone\u2019s calendar adapts around shared commitments automatically \u2014 no extra apps needed.",
+					"badge": "Collaboration"
+				}
+			}
 		}
 	}
 }

--- a/src/pages/Newsletter.tsx
+++ b/src/pages/Newsletter.tsx
@@ -10,6 +10,7 @@ import {
   HeroSubtitle,
   BackgroundBlur,
 } from '../components/discover/shared';
+import FeaturesSection from '../components/discover/FeaturesSection';
 
 const Newsletter: React.FC = () => {
   const { t } = useTranslation();
@@ -29,6 +30,8 @@ const Newsletter: React.FC = () => {
             <HeroTitle>{t('discover.hero.title')}</HeroTitle>
             <HeroSubtitle>{t('discover.hero.subtitle')}</HeroSubtitle>
           </Hero>
+
+          <FeaturesSection />
         </PageWrapper>
       </Section>
     </>


### PR DESCRIPTION
Closes #114

## Summary
- Adds the **Features** expandable section to the Discover page
- 14 feature cards in a responsive 3-column grid (2-col on mobile, 1-col on small screens)
- Each card has an icon, name, description, and category badge (Core feature, Unique to Tiler, Integration, etc.)
- Header visual shows a 3×3 icon grid preview
- All text fully internationalized via `react-i18next` with keys under `discover.features`
- Self-contained in `FeaturesSection.tsx` — can be reverted independently

## Test plan
- [ ] Verify the section renders on `/newsletter`
- [ ] Click to expand and verify all 14 feature cards display correctly
- [ ] Verify responsive grid layout at various breakpoints (540px, 360px)
- [ ] Verify hover effects on cards (border highlight + translateY)
- [ ] Check i18n keys load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)