### PR TITLE
Rename /newsletter route to /discover

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,7 @@ const App: React.FC = () => {
 							<Routes>
 								<Route path="/" element={<Layout />}>
 									<Route index element={<Home />} />
-									<Route path="/newsletter" element={<Newsletter />} />
+									<Route path="/discover" element={<Newsletter />} />
 								</Route>
 								<Route
 									path="/waitlist"

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -172,7 +172,7 @@ const Navigation: React.FC = () => {
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const navLinks = [
 		{ name: t('common.navigation.home'), href: '/' },
-		{ name: t('common.navigation.discover'), href: '/newsletter' },
+		{ name: t('common.navigation.discover'), href: '/discover' },
 	];
 
 	function handleScroll() {

--- a/src/pages/Newsletter.tsx
+++ b/src/pages/Newsletter.tsx
@@ -23,7 +23,7 @@ const Newsletter: React.FC = () => {
 			<SEO
 				title={t('discover.seo.title')}
 				description={t('discover.seo.description')}
-				canonicalUrl="/newsletter"
+				canonicalUrl="/discover"
 			/>
 			<Section>
 				<BackgroundBlur />


### PR DESCRIPTION
Closes #155

## Summary
- Update route path from `/newsletter` to `/discover` in `App.tsx`
- Update nav link href in `navigation.tsx`
- Update canonical URL in `Newsletter.tsx`

## Test plan
- [ ] Visit `/discover` — page loads with all Discover sections
- [ ] Nav bar "Discover" link points to `/discover`
- [ ] `/newsletter` no longer resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)