### PR TITLE
Bug/jb/addtile and repetition and restriction update

### DIFF
--- a/src/core/common/components/calendar/create_tile/__tests__/CreateTileActionsOptions.test.tsx
+++ b/src/core/common/components/calendar/create_tile/__tests__/CreateTileActionsOptions.test.tsx
@@ -9,12 +9,13 @@ import { ThemeProvider } from '@/core/theme/ThemeProvider';
 import { CalendarUIProvider } from '../../calendar-ui.provider';
 import CreateTileActionsOptions from '../options.actions';
 import type { OptionsFormController } from '../options';
-import { CreateTileRestrictionType } from '../../data';
+import { CreateTileRestrictionType, initialCreateTileFormState } from '../../data';
 import {
 	ScheduleRepeatEndType,
 	ScheduleRepeatFrequency,
 	ScheduleRepeatStartType,
 	ScheduleRepeatType,
+	ScheduleRepeatWeekday,
 	type DaySchedule,
 } from '@/core/common/types/schedule';
 import { RGBColor } from '@/core/util/colors';
@@ -153,5 +154,128 @@ describe('CreateTileActionsOptions - custom restriction day selection', () => {
 		expect(snapshot[1].endTime).toBe('');
 		expect(snapshot[3].startTime).not.toBe('');
 		expect(snapshot[3].endTime).not.toBe('');
+	});
+});
+
+// ── Weekly recurrence day selection ───────────────────────────────────────────
+
+/**
+ * Harness for the weekly-days picker.
+ * Mirrors how CalendarCreateTile wires setRecurrenceWeeklyDays through
+ * useFormHandler — a plain value setter, not a functional updater.
+ */
+const WeeklyHarness: React.FC<{
+	initialDays?: ScheduleRepeatWeekday[];
+	onDaysChange?: (days: ScheduleRepeatWeekday[]) => void;
+}> = ({ initialDays = [], onDaysChange }) => {
+	const [days, setDays] = useState<ScheduleRepeatWeekday[]>(initialDays);
+
+	const controller: OptionsFormController = {
+		start: dayjs(),
+		color: new RGBColor(0, 0, 0),
+		setColor: () => {},
+		recurring: true,
+		setRecurring: () => {},
+		recurrenceType: ScheduleRepeatType.Weekly,
+		setRecurrenceType: () => {},
+		recurrenceFrequency: ScheduleRepeatFrequency.Weekly,
+		setRecurrenceFrequency: () => {},
+		recurrenceWeeklyDays: days,
+		setRecurrenceWeeklyDays: (next) => {
+			setDays(next);
+			onDaysChange?.(next);
+		},
+		recurrenceStartType: ScheduleRepeatStartType.Default,
+		setRecurrenceStartType: () => {},
+		recurrenceStartDate: dayjs(),
+		setRecurrenceStartDate: () => {},
+		recurrenceEndType: ScheduleRepeatEndType.Never,
+		setRecurrenceEndType: () => {},
+		recurrenceEndDate: dayjs().add(1, 'week'),
+		setRecurrenceEndDate: () => {},
+	};
+
+	return (
+		<>
+			<CreateTileActionsOptions controller={controller} />
+			<div data-testid="days-snapshot">{JSON.stringify(days)}</div>
+		</>
+	);
+};
+
+function renderWeeklyHarness(props: React.ComponentProps<typeof WeeklyHarness> = {}) {
+	return render(
+		<ThemeProvider defaultTheme="dark">
+			<CalendarUIProvider demoMode={false}>
+				<WeeklyHarness {...props} />
+			</CalendarUIProvider>
+		</ThemeProvider>
+	);
+}
+
+function readDays(): ScheduleRepeatWeekday[] {
+	return JSON.parse(screen.getByTestId('days-snapshot').textContent || '[]');
+}
+
+// The weekday buttons carry a `title` attribute equal to the translated label.
+// With `t: (key) => key` the label key for Monday is the full i18n key; we
+// match on the suffix via regex.
+const dayTitle = (suffix: string) => new RegExp(`recurrenceWeeklyDays\\.${suffix}$`);
+
+describe('initialCreateTileFormState', () => {
+	it('starts with no pre-selected recurrence weekdays', () => {
+		expect(initialCreateTileFormState.recurrenceWeeklyDays).toEqual([]);
+	});
+});
+
+describe('CreateTileActionsOptions - recurrence weekly days', () => {
+	it('renders no day as pre-selected when weeklyDays is empty', async () => {
+		renderWeeklyHarness({ initialDays: [] });
+		expect(readDays()).toEqual([]);
+	});
+
+	it('user can select a weekday', async () => {
+		const user = userEvent.setup();
+		renderWeeklyHarness({ initialDays: [] });
+
+		await user.click(screen.getByTitle(dayTitle('monday')));
+
+		expect(readDays()).toContain(ScheduleRepeatWeekday.Monday);
+	});
+
+	it('user can select multiple weekdays independently', async () => {
+		const user = userEvent.setup();
+		renderWeeklyHarness({ initialDays: [] });
+
+		await user.click(screen.getByTitle(dayTitle('monday')));
+		await user.click(screen.getByTitle(dayTitle('wednesday')));
+		await user.click(screen.getByTitle(dayTitle('friday')));
+
+		const days = readDays();
+		expect(days).toContain(ScheduleRepeatWeekday.Monday);
+		expect(days).toContain(ScheduleRepeatWeekday.Wednesday);
+		expect(days).toContain(ScheduleRepeatWeekday.Friday);
+	});
+
+	it('user can deselect a day when multiple are selected', async () => {
+		const user = userEvent.setup();
+		renderWeeklyHarness({
+			initialDays: [ScheduleRepeatWeekday.Monday, ScheduleRepeatWeekday.Wednesday],
+		});
+
+		await user.click(screen.getByTitle(dayTitle('monday')));
+
+		const days = readDays();
+		expect(days).not.toContain(ScheduleRepeatWeekday.Monday);
+		expect(days).toContain(ScheduleRepeatWeekday.Wednesday);
+	});
+
+	it('user can deselect the last remaining selected day (array becomes empty)', async () => {
+		const user = userEvent.setup();
+		renderWeeklyHarness({ initialDays: [ScheduleRepeatWeekday.Monday] });
+
+		await user.click(screen.getByTitle(dayTitle('monday')));
+
+		expect(readDays()).toEqual([]);
 	});
 });

--- a/src/core/common/components/calendar/create_tile/info.tsx
+++ b/src/core/common/components/calendar/create_tile/info.tsx
@@ -7,7 +7,6 @@ import DatePicker from '../../date_picker';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import LocationInput, { LocationInputController } from '../../location-input';
-import { ScheduleRepeatWeekday } from '@/core/common/types/schedule';
 
 type InfoProps = {
 	formHandler: ReturnType<typeof useFormHandler<InitialCreateTileFormState>>;
@@ -75,11 +74,9 @@ const CreateTileInfo: React.FC<InfoProps> = ({
 				value={formData.count}
 				onChange={(e) => {
 					const value = Math.max(1, parseInt(e.target.value, 10) || 1).toString();
-					const clickedWeekday = String(formData.start.day()) as ScheduleRepeatWeekday;
 					setFormData((prev) => ({
 						...prev,
 						count: value,
-						recurrenceWeeklyDays: parseInt(value, 10) > 1 ? [] : [clickedWeekday],
 					}));
 				}}
 			/>

--- a/src/core/common/components/calendar/create_tile/options.actions.tsx
+++ b/src/core/common/components/calendar/create_tile/options.actions.tsx
@@ -227,16 +227,13 @@ const CreateTileActionsOptions: React.FC<ActionsOptionsProps> = ({
 												controller.recurrenceWeeklyDays.includes(
 													option.value
 												);
-											const allowUnselect =
-												controller.recurrenceWeeklyDays.length > 1;
-											if (isSelected && allowUnselect) {
+											if (isSelected) {
 												controller.setRecurrenceWeeklyDays(
 													controller.recurrenceWeeklyDays.filter(
 														(day) => day !== option.value
 													)
 												);
-											}
-											if (!isSelected) {
+											} else {
 												controller.setRecurrenceWeeklyDays(
 													controller.recurrenceWeeklyDays.concat(
 														option.value

--- a/src/core/common/components/calendar/data.ts
+++ b/src/core/common/components/calendar/data.ts
@@ -6,7 +6,6 @@ import {
 	ScheduleRepeatFrequency,
 	ScheduleRepeatStartType,
 	ScheduleRepeatType,
-	ScheduleRepeatWeekday,
 } from '../../types/schedule';
 import { eventColors } from '@/core/constants/calendar_options';
 import { InitialCreateBlockFormState } from './create_block';
@@ -36,7 +35,7 @@ export const initialCreateTileFormState: InitialCreateTileFormState = {
 	isRecurring: false,
 	recurrenceType: ScheduleRepeatType.Daily,
 	recurrenceFrequency: ScheduleRepeatFrequency.Daily,
-	recurrenceWeeklyDays: [ScheduleRepeatWeekday.Sunday],
+	recurrenceWeeklyDays: [],
 	recurrenceStartType: ScheduleRepeatStartType.Default,
 	recurrenceStartDate: dayjs(),
 	recurrenceEndType: ScheduleRepeatEndType.Never,
@@ -67,7 +66,7 @@ export const initialCreateBlockFormState: InitialCreateBlockFormState = {
 	isRecurring: false,
 	recurrenceType: ScheduleRepeatType.Daily,
 	recurrenceFrequency: ScheduleRepeatFrequency.Daily,
-	recurrenceWeeklyDays: [ScheduleRepeatWeekday.Sunday],
+	recurrenceWeeklyDays: [],
 	recurrenceStartType: ScheduleRepeatStartType.Default,
 	recurrenceStartDate: dayjs(),
 	recurrenceEndType: ScheduleRepeatEndType.Never,


### PR DESCRIPTION
This pull request updates the recurrence weekday selection logic for creating calendar tiles, making it more flexible and user-friendly. The main changes are the removal of the restriction that required at least one weekday to be selected for weekly recurrences, updates to initial form state to start with no pre-selected days, and the addition of comprehensive tests for the new behavior.

### Recurrence weekday selection improvements

* The logic for weekly recurrence day selection in `CreateTileActionsOptions` was updated so that users can now deselect all weekdays, not just down to one. Previously, at least one weekday had to remain selected.
* The initial form state for both tile and block creation (`initialCreateTileFormState` and `initialCreateBlockFormState` in `data.ts`) now starts with an empty `recurrenceWeeklyDays` array instead of defaulting to Sunday. [[1]](diffhunk://#diff-f139b582b281cf079c7766a04516066a7185637273e7796ea5c0045ebafe71b8L39-R38) [[2]](diffhunk://#diff-f139b582b281cf079c7766a04516066a7185637273e7796ea5c0045ebafe71b8L70-R69)

### Testing enhancements

* Added a new test harness and a comprehensive suite of tests for weekly recurrence day selection, ensuring correct behavior for selecting and deselecting weekdays, including the ability to clear all selections.
* Added a test to verify that the initial form state starts with no pre-selected recurrence weekdays.

### Code cleanup

* Removed unused imports of `ScheduleRepeatWeekday` from files where it was no longer needed. [[1]](diffhunk://#diff-f139b582b281cf079c7766a04516066a7185637273e7796ea5c0045ebafe71b8L9) [[2]](diffhunk://#diff-819a4d4fa12f64189056420f2243ba720c267839d1249726e09fbb14b74f46edL10)
* Cleaned up the logic in the recurrence count input handler by removing unused code related to automatic weekday selection.

### Dependency updates

* Updated imports in test files to include `initialCreateTileFormState` and `ScheduleRepeatWeekday` as needed for the new tests.