### PR TITLE
Create Tileshare (Single & Multi)

### DIFF
--- a/src/api/__tests__/tileshareApi.test.ts
+++ b/src/api/__tests__/tileshareApi.test.ts
@@ -236,4 +236,58 @@ describe('TileshareApi', () => {
 			await expect(api.deleteCluster(deleteParams)).rejects.toThrow();
 		});
 	});
+
+	describe('createCluster', () => {
+		const createParams = {
+			UserName: 'test@example.com',
+			TimeZone: 'America/Denver',
+			TimeZoneOffset: 360,
+			Name: 'Finish tax documents',
+			IsMultiTilette: false,
+			IncludeMe: true,
+			EndTime: 1751932800000,
+			DurationInMs: 3600000,
+			Notes: 'Bring last year returns',
+			AddressData: { Address: '123 Main St', AddressIsVerified: false },
+			Contacts: [{ Email: 'jane@example.com' }],
+		};
+
+		it('sends POST request to api/TileShareCluster with the JSON body', async () => {
+			fetchSpy.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						Error: { Code: '0', Message: 'SUCCESS' },
+						Content: { cluster: mockCluster },
+						ServerStatus: null,
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				)
+			);
+
+			await api.createCluster(createParams);
+
+			expect(fetchSpy).toHaveBeenCalledOnce();
+			const [urlArg, options] = fetchSpy.mock.calls[0];
+			const urlStr =
+				urlArg instanceof Request
+					? urlArg.url
+					: typeof urlArg === 'string'
+						? urlArg
+						: String(urlArg);
+			expect(urlStr).toContain('api/TileShareCluster');
+			const method = urlArg instanceof Request ? urlArg.method : options?.method;
+			expect(method).toBe('POST');
+			const bodyStr =
+				urlArg instanceof Request ? await urlArg.text() : (options?.body as string);
+			const body = JSON.parse(bodyStr);
+			expect(body.Name).toBe('Finish tax documents');
+			expect(body.IsMultiTilette).toBe(false);
+			expect(body.Contacts).toEqual([{ Email: 'jane@example.com' }]);
+		});
+
+		it('throws on network error', async () => {
+			fetchSpy.mockRejectedValueOnce(new Error('Network error'));
+			await expect(api.createCluster(createParams)).rejects.toThrow();
+		});
+	});
 });

--- a/src/api/tileshareApi.ts
+++ b/src/api/tileshareApi.ts
@@ -1,5 +1,7 @@
 import { AppApi } from './appApi';
 import {
+	CreateTileShareClusterParams,
+	CreateTileShareClusterResponse,
 	DeleteTileShareClusterParams,
 	DeleteTileShareClusterResponse,
 	DesignatedTileListResponse,
@@ -31,6 +33,13 @@ export class TileshareApi extends AppApi {
 				).toString()
 			: '';
 		return this.apiRequest<DesignatedTileListResponse>(`api/DesignatedTile/designated${qs}`);
+	}
+
+	createCluster(body: CreateTileShareClusterParams) {
+		return this.apiRequest<CreateTileShareClusterResponse>('api/TileShareCluster', {
+			method: 'POST',
+			body: JSON.stringify(body),
+		});
 	}
 
 	async deleteCluster(

--- a/src/components/tileshare/TileshareCreate.tsx
+++ b/src/components/tileshare/TileshareCreate.tsx
@@ -1,0 +1,268 @@
+import React from 'react';
+import styled, { useTheme } from 'styled-components';
+import { useTranslation } from 'react-i18next';
+import { ChevronLeft, Layers, MapPin, MessageSquare, Plus } from 'lucide-react';
+import useFormHandler from '@/hooks/useFormHandler';
+import Input from '@/core/common/components/input';
+import DatePicker from '@/core/common/components/date_picker';
+import Button from '@/core/common/components/button';
+
+export enum TileshareMode {
+	Single = 'single',
+	Multi = 'multi',
+}
+
+type TileshareCreateProps = {
+	mode: TileshareMode;
+	onBack: () => void;
+};
+
+type TileshareFormState = {
+	name: string;
+	deadline: string;
+	location: string;
+	note: string;
+	shareTo: string;
+};
+
+const initialTileshareFormState: TileshareFormState = {
+	name: '',
+	deadline: '',
+	location: '',
+	note: '',
+	shareTo: '',
+};
+
+const TileshareCreate: React.FC<TileshareCreateProps> = ({ mode, onBack }) => {
+	const theme = useTheme();
+	const { t } = useTranslation();
+	const { formData, handleFormInputChange } =
+		useFormHandler<TileshareFormState>(initialTileshareFormState);
+
+	const isSingle = mode === TileshareMode.Single;
+	const ModeIcon = isSingle ? MessageSquare : Layers;
+
+	return (
+		<Container>
+			<HeaderBar>
+				<BackButton type="button" onClick={onBack}>
+					<ChevronLeft size={18} />
+					{t('tilesharedemo.dashboard.create.back')}
+				</BackButton>
+			</HeaderBar>
+
+			<Content>
+				<IconBox>
+					<ModeIcon size={20} />
+				</IconBox>
+
+				<Title>{t(`tilesharedemo.dashboard.create.${mode}.title`)}</Title>
+				<Description>{t(`tilesharedemo.dashboard.create.${mode}.description`)}</Description>
+
+				<Fields>
+					<Input
+						name="name"
+						placeholder={t('tilesharedemo.dashboard.create.fields.name.placeholder')}
+						value={formData.name}
+						onChange={handleFormInputChange('name')}
+					/>
+
+					<DatePicker
+						value={formData.deadline}
+						onChange={handleFormInputChange('deadline', { mode: 'static' })}
+						placeholder={t(
+							'tilesharedemo.dashboard.create.fields.deadline.placeholder'
+						)}
+					/>
+
+					<Input
+						name="location"
+						placeholder={t(
+							'tilesharedemo.dashboard.create.fields.location.placeholder'
+						)}
+						value={formData.location}
+						onChange={handleFormInputChange('location')}
+						append={<MapPin size={16} />}
+					/>
+
+					<Input.Textarea
+						name="note"
+						placeholder={t('tilesharedemo.dashboard.create.fields.note.placeholder')}
+						value={formData.note}
+						onChange={handleFormInputChange('note')}
+						height={180}
+					/>
+
+					{isSingle && (
+						<ShareTo>
+							<ShareToLabel>
+								{t('tilesharedemo.dashboard.create.shareTo.label')}
+							</ShareToLabel>
+							<Input
+								name="shareTo"
+								placeholder={t(
+									'tilesharedemo.dashboard.create.shareTo.placeholder'
+								)}
+								value={formData.shareTo}
+								onChange={handleFormInputChange('shareTo')}
+								append={
+									<AddButton
+										type="button"
+										aria-label={t('tilesharedemo.dashboard.create.shareTo.add')}
+									>
+										<Plus size={16} />
+									</AddButton>
+								}
+							/>
+						</ShareTo>
+					)}
+				</Fields>
+
+				<Footer>
+					<Separator />
+					<Actions>
+						<Button
+							type="button"
+							variant="ghost"
+							style={{
+								border: `1px solid ${theme.colors.border.default}`,
+							}}
+							onClick={onBack}
+						>
+							{t('tilesharedemo.dashboard.create.buttons.cancel')}
+						</Button>
+						<Button type="button" variant="brand">
+							{t(`tilesharedemo.dashboard.create.${mode}.submit`)}
+						</Button>
+					</Actions>
+				</Footer>
+			</Content>
+		</Container>
+	);
+};
+
+const Container = styled.div`
+	width: 100%;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	overflow-y: auto;
+`;
+
+const HeaderBar = styled.header`
+	position: sticky;
+	top: 0;
+	z-index: 1;
+	display: flex;
+	align-items: center;
+	padding: 1rem 1.5rem;
+	background-color: ${({ theme }) => theme.colors.background.page};
+	border-bottom: 1px solid ${({ theme }) => theme.colors.border.subtle};
+`;
+
+const BackButton = styled.button`
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	color: ${({ theme }) => theme.colors.text.secondary};
+	font-family: ${({ theme }) => theme.typography.fontFamily.urban};
+	font-weight: ${({ theme }) => theme.typography.fontWeight.semibold};
+	font-size: ${({ theme }) => theme.typography.fontSize.sm};
+	transition: color 0.2s ease;
+
+	&:hover {
+		color: ${({ theme }) => theme.colors.text.primary};
+	}
+`;
+
+const Content = styled.div`
+	width: 100%;
+	max-width: ${({ theme }) => theme.screens.md};
+	margin-inline: auto;
+	padding: 2.5rem 1.5rem 2rem;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+`;
+
+const IconBox = styled.div`
+	width: 56px;
+	height: 56px;
+	border-radius: ${({ theme }) => theme.borderRadius.large};
+	border: 1px solid ${({ theme }) => theme.colors.border.strong};
+	color: ${({ theme }) => theme.colors.text.primary};
+	display: flex;
+	align-items: center;
+	justify-content: center;
+`;
+
+const Title = styled.h2`
+	margin-top: 1.5rem;
+	font-family: ${({ theme }) => theme.typography.fontFamily.urban};
+	font-weight: ${({ theme }) => theme.typography.fontWeight.bold};
+	font-size: ${({ theme }) => theme.typography.fontSize.displayXs};
+	color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+const Description = styled.p`
+	margin-top: 0.5rem;
+	font-family: ${({ theme }) => theme.typography.fontFamily.inter};
+	font-size: ${({ theme }) => theme.typography.fontSize.base};
+	color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+const Fields = styled.div`
+	margin-top: 2rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+`;
+
+const ShareTo = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+`;
+
+const ShareToLabel = styled.label`
+	font-family: ${({ theme }) => theme.typography.fontFamily.urban};
+	font-weight: ${({ theme }) => theme.typography.fontWeight.semibold};
+	font-size: ${({ theme }) => theme.typography.fontSize.sm};
+	color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+const AddButton = styled.button`
+	height: 28px;
+	width: 28px;
+	color: ${({ theme }) => theme.colors.button.brand.text};
+	background-color: ${({ theme }) => theme.colors.button.brand.bg};
+	border-radius: ${({ theme }) => theme.borderRadius.medium};
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	&:hover {
+		background-color: ${({ theme }) => theme.colors.button.brand.bgHover};
+	}
+`;
+
+const Footer = styled.div`
+	margin-top: 2rem;
+	display: flex;
+	flex-direction: column;
+`;
+
+const Separator = styled.hr`
+	border: none;
+	height: 0.5px;
+	background-color: ${({ theme }) => theme.colors.border.subtle};
+`;
+
+const Actions = styled.div`
+	margin-top: 1.5rem;
+	display: flex;
+	justify-content: flex-end;
+	gap: 0.75rem;
+`;
+
+export default TileshareCreate;

--- a/src/components/tileshare/TileshareCreate.tsx
+++ b/src/components/tileshare/TileshareCreate.tsx
@@ -1,28 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 import { useTranslation } from 'react-i18next';
-import { ChevronLeft, Layers, MapPin, MessageSquare, Plus } from 'lucide-react';
+import { ChevronLeft, Layers, MapPin, MessageSquare } from 'lucide-react';
 import useFormHandler from '@/hooks/useFormHandler';
 import Input from '@/core/common/components/input';
 import DatePicker from '@/core/common/components/date_picker';
 import Button from '@/core/common/components/button';
-
-export enum TileshareMode {
-	Single = 'single',
-	Multi = 'multi',
-}
+import TagInput from '@/core/common/components/TagInput';
+import { useAuth } from '@/core/auth/useAuth';
+import { useUiStore, notificationId, NotificationAction } from '@/core/ui';
+import { tileshareService } from '@/services';
+import { toCreateClusterParams } from '@/services/tileshareService';
+import { TileshareFormState, TileshareMode } from '@/core/common/types/tileshare';
+import { isValidRecipient } from '@/core/util/contact';
+import { DEFAULT_COUNTRY_CODE } from '@/core/constants/countryCodes';
+export { TileshareMode };
 
 type TileshareCreateProps = {
 	mode: TileshareMode;
 	onBack: () => void;
-};
-
-type TileshareFormState = {
-	name: string;
-	deadline: string;
-	location: string;
-	note: string;
-	shareTo: string;
 };
 
 const initialTileshareFormState: TileshareFormState = {
@@ -30,17 +26,82 @@ const initialTileshareFormState: TileshareFormState = {
 	deadline: '',
 	location: '',
 	note: '',
-	shareTo: '',
+	recipients: [],
 };
+
+const CREATE_NOTIFICATION_ID = notificationId(NotificationAction.CreateTileshare, 'cluster');
 
 const TileshareCreate: React.FC<TileshareCreateProps> = ({ mode, onBack }) => {
 	const theme = useTheme();
 	const { t } = useTranslation();
-	const { formData, handleFormInputChange } =
+	const { user } = useAuth();
+	const showNotification = useUiStore((s) => s.notification.show);
+	const updateNotification = useUiStore((s) => s.notification.update);
+	const { formData, handleFormInputChange, setFormData, resetForm } =
 		useFormHandler<TileshareFormState>(initialTileshareFormState);
+	const [submitting, setSubmitting] = useState(false);
 
 	const isSingle = mode === TileshareMode.Single;
 	const ModeIcon = isSingle ? MessageSquare : Layers;
+
+	/** Returns the first validation problem as a message, or null when valid. */
+	const getValidationError = (): string | null => {
+		if (!formData.name.trim()) {
+			return t('tilesharedemo.dashboard.create.validation.nameRequired');
+		}
+		if (!formData.deadline) {
+			return t('tilesharedemo.dashboard.create.validation.deadlineRequired');
+		}
+		const invalid = formData.recipients.find((r) => !isValidRecipient(r));
+		if (invalid) {
+			return t('tilesharedemo.dashboard.create.validation.invalidRecipient', {
+				recipient: invalid,
+			});
+		}
+		return null;
+	};
+
+	const handleSubmit = async () => {
+		if (submitting) return;
+
+		const validationError = getValidationError();
+		if (validationError) {
+			showNotification(CREATE_NOTIFICATION_ID, validationError, 'error');
+			return;
+		}
+
+		const params = toCreateClusterParams(formData, mode, {
+			userName: user?.email ?? null,
+			timeZone: user?.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+			timeZoneOffset: user?.timeZoneDifference ?? 0,
+			defaultCallingCode: user?.countryCode?.trim() || String(DEFAULT_COUNTRY_CODE.code),
+		});
+
+		setSubmitting(true);
+		showNotification(
+			CREATE_NOTIFICATION_ID,
+			t('tilesharedemo.dashboard.create.toast.creating'),
+			'loading'
+		);
+		try {
+			await tileshareService.createCluster(params);
+			updateNotification(
+				CREATE_NOTIFICATION_ID,
+				t('tilesharedemo.dashboard.create.toast.success'),
+				'success'
+			);
+			resetForm();
+			onBack();
+		} catch {
+			updateNotification(
+				CREATE_NOTIFICATION_ID,
+				t('tilesharedemo.dashboard.create.toast.error'),
+				'error'
+			);
+		} finally {
+			setSubmitting(false);
+		}
+	};
 
 	return (
 		<Container>
@@ -90,7 +151,7 @@ const TileshareCreate: React.FC<TileshareCreateProps> = ({ mode, onBack }) => {
 						placeholder={t('tilesharedemo.dashboard.create.fields.note.placeholder')}
 						value={formData.note}
 						onChange={handleFormInputChange('note')}
-						height={180}
+						rows={6}
 					/>
 
 					{isSingle && (
@@ -98,21 +159,21 @@ const TileshareCreate: React.FC<TileshareCreateProps> = ({ mode, onBack }) => {
 							<ShareToLabel>
 								{t('tilesharedemo.dashboard.create.shareTo.label')}
 							</ShareToLabel>
-							<Input
-								name="shareTo"
+							<TagInput
+								value={formData.recipients}
+								onChange={(recipients) =>
+									setFormData((prev) => ({ ...prev, recipients }))
+								}
 								placeholder={t(
 									'tilesharedemo.dashboard.create.shareTo.placeholder'
 								)}
-								value={formData.shareTo}
-								onChange={handleFormInputChange('shareTo')}
-								append={
-									<AddButton
-										type="button"
-										aria-label={t('tilesharedemo.dashboard.create.shareTo.add')}
-									>
-										<Plus size={16} />
-									</AddButton>
+								addLabel={t('tilesharedemo.dashboard.create.shareTo.add')}
+								removeLabel={(recipient) =>
+									t('tilesharedemo.dashboard.create.shareTo.remove', {
+										recipient,
+									})
 								}
+								inputProps={{ name: 'shareTo' }}
 							/>
 						</ShareTo>
 					)}
@@ -131,7 +192,12 @@ const TileshareCreate: React.FC<TileshareCreateProps> = ({ mode, onBack }) => {
 						>
 							{t('tilesharedemo.dashboard.create.buttons.cancel')}
 						</Button>
-						<Button type="button" variant="brand">
+						<Button
+							type="button"
+							variant="brand"
+							onClick={handleSubmit}
+							disabled={submitting}
+						>
 							{t(`tilesharedemo.dashboard.create.${mode}.submit`)}
 						</Button>
 					</Actions>
@@ -143,10 +209,19 @@ const TileshareCreate: React.FC<TileshareCreateProps> = ({ mode, onBack }) => {
 
 const Container = styled.div`
 	width: 100%;
-	height: 100%;
 	display: flex;
 	flex-direction: column;
 	overflow-y: auto;
+`;
+
+const Content = styled.div`
+	width: 100%;
+	max-width: ${({ theme }) => theme.screens.md};
+	margin-inline: auto;
+	padding: 2.5rem 1.5rem 2rem;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
 `;
 
 const HeaderBar = styled.header`
@@ -175,22 +250,13 @@ const BackButton = styled.button`
 	}
 `;
 
-const Content = styled.div`
-	width: 100%;
-	max-width: ${({ theme }) => theme.screens.md};
-	margin-inline: auto;
-	padding: 2.5rem 1.5rem 2rem;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-`;
-
 const IconBox = styled.div`
 	width: 56px;
 	height: 56px;
 	border-radius: ${({ theme }) => theme.borderRadius.large};
 	border: 1px solid ${({ theme }) => theme.colors.border.strong};
 	color: ${({ theme }) => theme.colors.text.primary};
+	background-color: ${({ theme }) => theme.colors.background.card};
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -229,21 +295,6 @@ const ShareToLabel = styled.label`
 	font-weight: ${({ theme }) => theme.typography.fontWeight.semibold};
 	font-size: ${({ theme }) => theme.typography.fontSize.sm};
 	color: ${({ theme }) => theme.colors.text.secondary};
-`;
-
-const AddButton = styled.button`
-	height: 28px;
-	width: 28px;
-	color: ${({ theme }) => theme.colors.button.brand.text};
-	background-color: ${({ theme }) => theme.colors.button.brand.bg};
-	border-radius: ${({ theme }) => theme.borderRadius.medium};
-	display: flex;
-	align-items: center;
-	justify-content: center;
-
-	&:hover {
-		background-color: ${({ theme }) => theme.colors.button.brand.bgHover};
-	}
 `;
 
 const Footer = styled.div`

--- a/src/components/tileshare/TileshareCreate.tsx
+++ b/src/components/tileshare/TileshareCreate.tsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
 import { ChevronLeft, Layers, MapPin, MessageSquare } from 'lucide-react';
 import useFormHandler from '@/hooks/useFormHandler';
 import Input from '@/core/common/components/input';
 import DatePicker from '@/core/common/components/date_picker';
 import Button from '@/core/common/components/button';
 import TagInput from '@/core/common/components/TagInput';
+import SuccessModal from '@/core/common/components/modals/success-modal';
 import { useAuth } from '@/core/auth/useAuth';
 import { useUiStore, notificationId, NotificationAction } from '@/core/ui';
 import { tileshareService } from '@/services';
@@ -14,6 +16,7 @@ import { toCreateClusterParams } from '@/services/tileshareService';
 import { TileshareFormState, TileshareMode } from '@/core/common/types/tileshare';
 import { isValidRecipient } from '@/core/util/contact';
 import { DEFAULT_COUNTRY_CODE } from '@/core/constants/countryCodes';
+import { Routes } from '@/core/constants/routes';
 export { TileshareMode };
 
 type TileshareCreateProps = {
@@ -30,16 +33,23 @@ const initialTileshareFormState: TileshareFormState = {
 };
 
 const CREATE_NOTIFICATION_ID = notificationId(NotificationAction.CreateTileshare, 'cluster');
+/** Seconds the success modal stays up before auto-advancing to the detail page. */
+const SUCCESS_MODAL_TIMEOUT_SECONDS = 15;
 
 const TileshareCreate: React.FC<TileshareCreateProps> = ({ mode, onBack }) => {
 	const theme = useTheme();
 	const { t } = useTranslation();
 	const { user } = useAuth();
+	const navigate = useNavigate();
 	const showNotification = useUiStore((s) => s.notification.show);
 	const updateNotification = useUiStore((s) => s.notification.update);
-	const { formData, handleFormInputChange, setFormData, resetForm } =
+	const dismissNotification = useUiStore((s) => s.notification.dismiss);
+	const { formData, handleFormInputChange, setFormData } =
 		useFormHandler<TileshareFormState>(initialTileshareFormState);
 	const [submitting, setSubmitting] = useState(false);
+	const [showSuccess, setShowSuccess] = useState(false);
+	const [createdClusterId, setCreatedClusterId] = useState<string | null>(null);
+	const [createdName, setCreatedName] = useState('');
 
 	const isSingle = mode === TileshareMode.Single;
 	const ModeIcon = isSingle ? MessageSquare : Layers;
@@ -51,6 +61,9 @@ const TileshareCreate: React.FC<TileshareCreateProps> = ({ mode, onBack }) => {
 		}
 		if (!formData.deadline) {
 			return t('tilesharedemo.dashboard.create.validation.deadlineRequired');
+		}
+		if (isSingle && formData.recipients.length === 0) {
+			return t('tilesharedemo.dashboard.create.validation.recipientRequired');
 		}
 		const invalid = formData.recipients.find((r) => !isValidRecipient(r));
 		if (invalid) {
@@ -84,14 +97,11 @@ const TileshareCreate: React.FC<TileshareCreateProps> = ({ mode, onBack }) => {
 			'loading'
 		);
 		try {
-			await tileshareService.createCluster(params);
-			updateNotification(
-				CREATE_NOTIFICATION_ID,
-				t('tilesharedemo.dashboard.create.toast.success'),
-				'success'
-			);
-			resetForm();
-			onBack();
+			const created = await tileshareService.createCluster(params);
+			dismissNotification(CREATE_NOTIFICATION_ID);
+			setCreatedClusterId(created?.id ?? null);
+			setCreatedName(created?.name ?? params.Name);
+			setShowSuccess(true);
 		} catch {
 			updateNotification(
 				CREATE_NOTIFICATION_ID,
@@ -100,6 +110,16 @@ const TileshareCreate: React.FC<TileshareCreateProps> = ({ mode, onBack }) => {
 			);
 		} finally {
 			setSubmitting(false);
+		}
+	};
+
+	/** On any close of the success modal, advance to the new cluster's detail page. */
+	const handleSuccessClose = (next: boolean) => {
+		setShowSuccess(next);
+		if (!next) {
+			navigate(
+				createdClusterId ? Routes.Tileshare.detail(createdClusterId) : Routes.Tileshare.sent
+			);
 		}
 	};
 
@@ -203,6 +223,20 @@ const TileshareCreate: React.FC<TileshareCreateProps> = ({ mode, onBack }) => {
 					</Actions>
 				</Footer>
 			</Content>
+
+			<SuccessModal
+				show={showSuccess}
+				setShow={handleSuccessClose}
+				closeTimeout={SUCCESS_MODAL_TIMEOUT_SECONDS}
+				actions={[
+					{
+						text: t('tilesharedemo.dashboard.create.success.view'),
+						onClick: () => handleSuccessClose(false),
+					},
+				]}
+			>
+				<p>{t('tilesharedemo.dashboard.create.success.message', { name: createdName })}</p>
+			</SuccessModal>
 		</Container>
 	);
 };

--- a/src/components/tileshare/TileshareCreateSelection.tsx
+++ b/src/components/tileshare/TileshareCreateSelection.tsx
@@ -1,0 +1,210 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { a, useSpring } from '@react-spring/web';
+import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
+import { ChevronRight, Layers, MessageSquare } from 'lucide-react';
+
+type TileshareCreateSelectionProps = {
+	open: boolean;
+	anchorRef: React.RefObject<HTMLElement | null>;
+	onClose: () => void;
+	onSelectSingle: () => void;
+	onSelectMulti: () => void;
+};
+
+const TileshareCreateSelection: React.FC<TileshareCreateSelectionProps> = ({
+	open,
+	anchorRef,
+	onClose,
+	onSelectSingle,
+	onSelectMulti,
+}) => {
+	const { t } = useTranslation();
+	const [pos, setPos] = useState({ top: 0, right: 0 });
+	const menuRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!open) return;
+		const rect = anchorRef.current?.getBoundingClientRect();
+		if (rect) {
+			setPos({ top: rect.bottom + 8, right: window.innerWidth - rect.right });
+		}
+	}, [open, anchorRef]);
+
+	useEffect(() => {
+		if (!open) return;
+		const handleClick = (e: MouseEvent) => {
+			if (
+				anchorRef.current?.contains(e.target as Node) ||
+				menuRef.current?.contains(e.target as Node)
+			)
+				return;
+			onClose();
+		};
+		document.addEventListener('mousedown', handleClick);
+		return () => document.removeEventListener('mousedown', handleClick);
+	}, [open, anchorRef, onClose]);
+
+	useEffect(() => {
+		if (!open) return;
+		const handleKey = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') onClose();
+		};
+		document.addEventListener('keydown', handleKey);
+		return () => document.removeEventListener('keydown', handleKey);
+	}, [open, onClose]);
+
+	const animation = useSpring({
+		opacity: open ? 1 : 0,
+		scale: open ? 1 : 0.9,
+		y: open ? 0 : -8,
+		config: { duration: 150 },
+	});
+
+	if (!open) return null;
+
+	function handleSelect(action: () => void) {
+		onClose();
+		action();
+	}
+
+	const singleDescription = t('tilesharedemo.dashboard.createSelection.single.description');
+	const multiDescription = t('tilesharedemo.dashboard.createSelection.multi.description');
+
+	return createPortal(
+		<Container
+			ref={menuRef}
+			style={{
+				top: pos.top,
+				right: pos.right,
+				opacity: animation.opacity,
+				transform: animation.y.to(
+					(y) => `translateY(${y}px) scale(${animation.scale.get()})`
+				),
+			}}
+		>
+			<Selection onClick={() => handleSelect(onSelectSingle)}>
+				<div>
+					<MessageSquare size={20} />
+				</div>
+				<TextBlock>
+					<h3>{t('tilesharedemo.dashboard.createSelection.single.label')}</h3>
+					{singleDescription && <p>{singleDescription}</p>}
+				</TextBlock>
+				<ChevronRight size={18} />
+			</Selection>
+			<Seperator />
+			<Selection onClick={() => handleSelect(onSelectMulti)}>
+				<div>
+					<Layers size={20} />
+				</div>
+				<TextBlock>
+					<h3>{t('tilesharedemo.dashboard.createSelection.multi.label')}</h3>
+					{multiDescription && <p>{multiDescription}</p>}
+				</TextBlock>
+				<ChevronRight size={18} />
+			</Selection>
+		</Container>,
+		document.body
+	);
+};
+
+const Seperator = styled.hr`
+	border: none;
+	height: 1px;
+	background-color: ${({ theme }) => theme.colors.border.subtle};
+`;
+
+const Container = styled(a.div)`
+	position: fixed;
+	z-index: 10000;
+	width: 280px;
+	background-color: ${({ theme }) => theme.colors.background.card};
+	border: 1px solid ${({ theme }) => theme.colors.border.default};
+	border-radius: ${({ theme }) => theme.borderRadius.large};
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+	transform-origin: top right;
+`;
+
+const Selection = styled.button`
+	display: flex;
+	gap: 0.75rem;
+	padding: 10px;
+
+	p {
+		font-size: ${({ theme }) => theme.typography.fontSize.sm};
+		font-family: ${({ theme }) => theme.typography.fontFamily.inter};
+		color: ${({ theme }) => theme.colors.text.muted};
+		text-align: left;
+	}
+
+	&:hover {
+		background-color: ${({ theme }) => `${theme.colors.brand[300]}05`};
+		& > :first-child {
+			background-color: ${({ theme }) => `${theme.colors.brand[500]}10`};
+			border-color: ${({ theme }) => `${theme.colors.brand[500]}20`};
+			color: ${({ theme }) => theme.colors.brand[400]};
+		}
+
+		& > :last-child {
+			opacity: 1;
+			transform: translateX(0);
+		}
+
+		h3 {
+			color: ${({ theme }) => theme.colors.text.primary};
+		}
+	}
+
+	& > :last-child {
+		margin-block: auto;
+		min-width: 36px;
+		color: ${({ theme }) => theme.colors.brand[400]};
+		opacity: 0;
+		transform: translateX(10px);
+		transition:
+			opacity 0.2s ease,
+			transform 0.2s ease;
+	}
+
+	& > :first-child {
+		margin-block: auto;
+		border-radius: ${({ theme }) => theme.borderRadius.medium};
+		border: 1px solid ${({ theme }) => theme.colors.border.strong};
+		color: ${({ theme }) => theme.colors.text.muted};
+		height: 36px;
+		aspect-ratio: 1 / 1;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+
+		transition:
+			background-color 0.2s ease,
+			border-color 0.2s ease,
+			color 0.2s ease;
+	}
+
+	h3 {
+		font-size: ${({ theme }) => theme.typography.fontSize.base};
+		font-family: ${({ theme }) => theme.typography.fontFamily.urban};
+		font-weight: ${({ theme }) => theme.typography.fontWeight.bold};
+		color: ${({ theme }) => theme.colors.text.secondary};
+		text-align: left;
+		transition: color 0.2s ease;
+	}
+
+	transition: background-color 0.2s ease;
+`;
+
+const TextBlock = styled.div`
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	flex: 1;
+`;
+
+export default TileshareCreateSelection;

--- a/src/components/tileshare/TileshareToolbar.tsx
+++ b/src/components/tileshare/TileshareToolbar.tsx
@@ -1,0 +1,102 @@
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
+import { Plus } from 'lucide-react';
+import AvatarCluster, { AvatarUser } from '@/core/common/components/AvatarCluster';
+import TileshareCreateSelection from './TileshareCreateSelection';
+
+type TileshareToolbarProps = {
+	user: AvatarUser;
+	onSelectSingle: () => void;
+	onSelectMulti: () => void;
+	className?: string;
+};
+
+const TileshareToolbar: React.FC<TileshareToolbarProps> = ({
+	user,
+	onSelectSingle,
+	onSelectMulti,
+	className,
+}) => {
+	const { t } = useTranslation();
+	const [isOpen, setIsOpen] = useState(false);
+	const createButtonRef = useRef<HTMLButtonElement>(null);
+
+	return (
+		<Toolbar className={className}>
+			<Welcome>
+				<AvatarCluster users={[user]} />
+				<Greeting>
+					<GreetingLine>{t('tilesharedemo.dashboard.toolbar.welcome')}</GreetingLine>
+					<UserName>{user.name}</UserName>
+				</Greeting>
+			</Welcome>
+			<CreateButton
+				ref={createButtonRef}
+				type="button"
+				onClick={() => setIsOpen((prev) => !prev)}
+				aria-label={t('tilesharedemo.dashboard.toolbar.create')}
+				aria-haspopup="menu"
+				aria-expanded={isOpen}
+			>
+				<Plus size={16} />
+			</CreateButton>
+			<TileshareCreateSelection
+				open={isOpen}
+				anchorRef={createButtonRef}
+				onClose={() => setIsOpen(false)}
+				onSelectSingle={onSelectSingle}
+				onSelectMulti={onSelectMulti}
+			/>
+		</Toolbar>
+	);
+};
+
+const Toolbar = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+`;
+
+const Welcome = styled.div`
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+`;
+
+const Greeting = styled.div`
+	display: flex;
+	flex-direction: column;
+`;
+
+const GreetingLine = styled.span`
+	font-family: ${({ theme }) => theme.typography.fontFamily.urban};
+	font-weight: ${({ theme }) => theme.typography.fontWeight.semibold};
+	font-size: ${({ theme }) => theme.typography.fontSize.sm};
+	color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+const UserName = styled.span`
+	font-family: ${({ theme }) => theme.typography.fontFamily.urban};
+	font-weight: ${({ theme }) => theme.typography.fontWeight.semibold};
+	font-size: ${({ theme }) => theme.typography.fontSize.sm};
+	color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+const CreateButton = styled.button`
+	height: 36px;
+	width: 36px;
+	overflow: hidden;
+	color: ${({ theme }) => theme.colors.button.brand.text};
+	background-color: ${({ theme }) => theme.colors.button.brand.bg};
+	border-radius: ${({ theme }) => theme.borderRadius.large};
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	&:hover {
+		background-color: ${({ theme }) => theme.colors.button.brand.bgHover};
+	}
+`;
+
+export default TileshareToolbar;

--- a/src/components/tileshare/__tests__/TileshareCreate.test.tsx
+++ b/src/components/tileshare/__tests__/TileshareCreate.test.tsx
@@ -1,17 +1,68 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@/test/test-utils';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render, screen, waitFor } from '@/test/test-utils';
 import { setupUser } from '@/test/test-utils';
 import TileshareCreate, { TileshareMode } from '../TileshareCreate';
+import { tileshareService } from '@/services';
 
 vi.mock('@/core/theme/ThemeProvider', () => ({
 	useTheme: () => ({ isDarkMode: false, toggleTheme: vi.fn() }),
 }));
 
-vi.mock('react-i18next', () => ({
-	useTranslation: () => ({ t: (key: string) => key }),
+vi.mock('react-i18next', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('react-i18next')>();
+	return {
+		...actual,
+		useTranslation: () => ({ t: (key: string) => key }),
+	};
+});
+
+vi.mock('@/services', () => ({
+	tileshareService: { createCluster: vi.fn() },
 }));
 
+vi.mock('@/core/auth/useAuth', () => ({
+	useAuth: () => ({
+		user: { email: 'me@example.com', timeZone: 'UTC', timeZoneDifference: 0 },
+	}),
+}));
+
+const { showNotification, updateNotification } = vi.hoisted(() => ({
+	showNotification: vi.fn(),
+	updateNotification: vi.fn(),
+}));
+
+vi.mock('@/core/ui', () => ({
+	useUiStore: (selector: (s: unknown) => unknown) =>
+		selector({ notification: { show: showNotification, update: updateNotification } }),
+	notificationId: () => 'create-tileshare-cluster',
+	NotificationAction: { CreateTileshare: 'create-tileshare' },
+}));
+
+// Replace the calendar DatePicker with a plain input so the date value can be typed.
+vi.mock('@/core/common/components/date_picker', () => ({
+	default: ({
+		value,
+		onChange,
+		placeholder,
+	}: {
+		value: string;
+		onChange: (v: string) => void;
+		placeholder?: string;
+	}) => (
+		<input placeholder={placeholder} value={value} onChange={(e) => onChange(e.target.value)} />
+	),
+}));
+
+const createCluster = tileshareService.createCluster as Mock;
+
 describe('TileshareCreate', () => {
+	beforeEach(() => {
+		createCluster.mockReset();
+		createCluster.mockResolvedValue({ cluster: { id: 'cluster-1' } });
+		showNotification.mockReset();
+		updateNotification.mockReset();
+	});
+
 	it('renders the single-mode copy, shared fields and the share-to field', () => {
 		render(<TileshareCreate mode={TileshareMode.Single} onBack={vi.fn()} />);
 
@@ -46,6 +97,33 @@ describe('TileshareCreate', () => {
 		).not.toBeInTheDocument();
 	});
 
+	it('adds multiple recipients as chips and removes them', async () => {
+		const user = setupUser();
+		render(<TileshareCreate mode={TileshareMode.Single} onBack={vi.fn()} />);
+
+		const recipientInput = screen.getByPlaceholderText(
+			'tilesharedemo.dashboard.create.shareTo.placeholder'
+		);
+		const addButton = screen.getByLabelText('tilesharedemo.dashboard.create.shareTo.add');
+
+		await user.type(recipientInput, 'jane@example.com');
+		await user.click(addButton);
+		await user.type(recipientInput, 'sam@example.com{Enter}');
+
+		expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+		expect(screen.getByText('sam@example.com')).toBeInTheDocument();
+		// Input is cleared after each add.
+		expect(recipientInput).toHaveValue('');
+
+		// Both remove buttons share the label under the identity-t mock; the first is jane's.
+		await user.click(
+			screen.getAllByLabelText('tilesharedemo.dashboard.create.shareTo.remove')[0]
+		);
+
+		expect(screen.queryByText('jane@example.com')).not.toBeInTheDocument();
+		expect(screen.getByText('sam@example.com')).toBeInTheDocument();
+	});
+
 	it('calls onBack from both the back button and the cancel button', async () => {
 		const user = setupUser();
 		const onBack = vi.fn();
@@ -55,5 +133,147 @@ describe('TileshareCreate', () => {
 		await user.click(screen.getByText('tilesharedemo.dashboard.create.buttons.cancel'));
 
 		expect(onBack).toHaveBeenCalledTimes(2);
+	});
+
+	it('blocks submit and shows an error notification when required fields are empty', async () => {
+		const user = setupUser();
+		render(<TileshareCreate mode={TileshareMode.Single} onBack={vi.fn()} />);
+
+		await user.click(screen.getByText('tilesharedemo.dashboard.create.single.submit'));
+
+		expect(showNotification).toHaveBeenCalledWith(
+			expect.any(String),
+			'tilesharedemo.dashboard.create.validation.nameRequired',
+			'error'
+		);
+		// No inline error text is rendered under the fields.
+		expect(
+			screen.queryByText('tilesharedemo.dashboard.create.validation.nameRequired')
+		).not.toBeInTheDocument();
+		expect(createCluster).not.toHaveBeenCalled();
+	});
+
+	it('blocks submit with an error notification when a recipient is invalid', async () => {
+		const user = setupUser();
+		render(<TileshareCreate mode={TileshareMode.Single} onBack={vi.fn()} />);
+
+		await user.type(
+			screen.getByPlaceholderText('tilesharedemo.dashboard.create.fields.name.placeholder'),
+			'Finish taxes'
+		);
+		await user.type(
+			screen.getByPlaceholderText(
+				'tilesharedemo.dashboard.create.fields.deadline.placeholder'
+			),
+			'2026-08-01'
+		);
+		await user.type(
+			screen.getByPlaceholderText('tilesharedemo.dashboard.create.shareTo.placeholder'),
+			'not-an-email{Enter}'
+		);
+
+		await user.click(screen.getByText('tilesharedemo.dashboard.create.single.submit'));
+
+		expect(showNotification).toHaveBeenCalledWith(
+			expect.any(String),
+			'tilesharedemo.dashboard.create.validation.invalidRecipient',
+			'error'
+		);
+		expect(createCluster).not.toHaveBeenCalled();
+	});
+
+	it('submits a mapped single-mode payload and returns to the dashboard on success', async () => {
+		const user = setupUser();
+		const onBack = vi.fn();
+		render(<TileshareCreate mode={TileshareMode.Single} onBack={onBack} />);
+
+		await user.type(
+			screen.getByPlaceholderText('tilesharedemo.dashboard.create.fields.name.placeholder'),
+			'Finish taxes'
+		);
+		await user.type(
+			screen.getByPlaceholderText(
+				'tilesharedemo.dashboard.create.fields.deadline.placeholder'
+			),
+			'2026-08-01'
+		);
+		await user.type(
+			screen.getByPlaceholderText('tilesharedemo.dashboard.create.shareTo.placeholder'),
+			'jane@example.com{Enter}'
+		);
+
+		await user.click(screen.getByText('tilesharedemo.dashboard.create.single.submit'));
+
+		await waitFor(() => expect(createCluster).toHaveBeenCalledTimes(1));
+		expect(createCluster).toHaveBeenCalledWith(
+			expect.objectContaining({
+				Name: 'Finish taxes',
+				IsMultiTilette: false,
+				IncludeMe: true,
+				UserName: 'me@example.com',
+				Contacts: [{ Email: 'jane@example.com' }],
+				EndTime: expect.any(Number),
+			})
+		);
+		await waitFor(() => expect(onBack).toHaveBeenCalledTimes(1));
+	});
+
+	it('normalizes a bare phone recipient with the default calling code on submit', async () => {
+		const user = setupUser();
+		render(<TileshareCreate mode={TileshareMode.Single} onBack={vi.fn()} />);
+
+		await user.type(
+			screen.getByPlaceholderText('tilesharedemo.dashboard.create.fields.name.placeholder'),
+			'Finish taxes'
+		);
+		await user.type(
+			screen.getByPlaceholderText(
+				'tilesharedemo.dashboard.create.fields.deadline.placeholder'
+			),
+			'2026-08-01'
+		);
+		await user.type(
+			screen.getByPlaceholderText('tilesharedemo.dashboard.create.shareTo.placeholder'),
+			'3035551212{Enter}'
+		);
+
+		await user.click(screen.getByText('tilesharedemo.dashboard.create.single.submit'));
+
+		await waitFor(() => expect(createCluster).toHaveBeenCalledTimes(1));
+		expect(createCluster).toHaveBeenCalledWith(
+			expect.objectContaining({
+				Contacts: [{ PhoneNumber: '+13035551212' }],
+			})
+		);
+	});
+
+	it('submits a multi-mode payload with IsMultiTilette and empty contacts', async () => {
+		const user = setupUser();
+		const onBack = vi.fn();
+		render(<TileshareCreate mode={TileshareMode.Multi} onBack={onBack} />);
+
+		await user.type(
+			screen.getByPlaceholderText('tilesharedemo.dashboard.create.fields.name.placeholder'),
+			'Product launch prep'
+		);
+		await user.type(
+			screen.getByPlaceholderText(
+				'tilesharedemo.dashboard.create.fields.deadline.placeholder'
+			),
+			'2026-08-01'
+		);
+
+		await user.click(screen.getByText('tilesharedemo.dashboard.create.multi.submit'));
+
+		await waitFor(() => expect(createCluster).toHaveBeenCalledTimes(1));
+		expect(createCluster).toHaveBeenCalledWith(
+			expect.objectContaining({
+				Name: 'Product launch prep',
+				IsMultiTilette: true,
+				Contacts: [],
+				EndTime: expect.any(Number),
+			})
+		);
+		await waitFor(() => expect(onBack).toHaveBeenCalledTimes(1));
 	});
 });

--- a/src/components/tileshare/__tests__/TileshareCreate.test.tsx
+++ b/src/components/tileshare/__tests__/TileshareCreate.test.tsx
@@ -26,17 +26,31 @@ vi.mock('@/core/auth/useAuth', () => ({
 	}),
 }));
 
-const { showNotification, updateNotification } = vi.hoisted(() => ({
+const { showNotification, updateNotification, dismissNotification } = vi.hoisted(() => ({
 	showNotification: vi.fn(),
 	updateNotification: vi.fn(),
+	dismissNotification: vi.fn(),
 }));
 
 vi.mock('@/core/ui', () => ({
 	useUiStore: (selector: (s: unknown) => unknown) =>
-		selector({ notification: { show: showNotification, update: updateNotification } }),
+		selector({
+			notification: {
+				show: showNotification,
+				update: updateNotification,
+				dismiss: dismissNotification,
+			},
+		}),
 	notificationId: () => 'create-tileshare-cluster',
 	NotificationAction: { CreateTileshare: 'create-tileshare' },
 }));
+
+const navigateMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('react-router')>();
+	return { ...actual, useNavigate: () => navigateMock };
+});
 
 // Replace the calendar DatePicker with a plain input so the date value can be typed.
 vi.mock('@/core/common/components/date_picker', () => ({
@@ -58,9 +72,11 @@ const createCluster = tileshareService.createCluster as Mock;
 describe('TileshareCreate', () => {
 	beforeEach(() => {
 		createCluster.mockReset();
-		createCluster.mockResolvedValue({ cluster: { id: 'cluster-1' } });
+		createCluster.mockResolvedValue({ id: 'cluster-1', name: 'Finish taxes' });
 		showNotification.mockReset();
 		updateNotification.mockReset();
+		dismissNotification.mockReset();
+		navigateMock.mockReset();
 	});
 
 	it('renders the single-mode copy, shared fields and the share-to field', () => {
@@ -215,7 +231,12 @@ describe('TileshareCreate', () => {
 				EndTime: expect.any(Number),
 			})
 		);
-		await waitFor(() => expect(onBack).toHaveBeenCalledTimes(1));
+
+		// Success modal appears (not onBack); closing it redirects to the detail page.
+		const viewAction = await screen.findByText('tilesharedemo.dashboard.create.success.view');
+		expect(onBack).not.toHaveBeenCalled();
+		await user.click(viewAction);
+		expect(navigateMock).toHaveBeenCalledWith('/tileshare/cluster-1');
 	});
 
 	it('normalizes a bare phone recipient with the default calling code on submit', async () => {
@@ -274,6 +295,10 @@ describe('TileshareCreate', () => {
 				EndTime: expect.any(Number),
 			})
 		);
-		await waitFor(() => expect(onBack).toHaveBeenCalledTimes(1));
+
+		const viewAction = await screen.findByText('tilesharedemo.dashboard.create.success.view');
+		expect(onBack).not.toHaveBeenCalled();
+		await user.click(viewAction);
+		expect(navigateMock).toHaveBeenCalledWith('/tileshare/cluster-1');
 	});
 });

--- a/src/components/tileshare/__tests__/TileshareCreate.test.tsx
+++ b/src/components/tileshare/__tests__/TileshareCreate.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@/test/test-utils';
+import { setupUser } from '@/test/test-utils';
+import TileshareCreate, { TileshareMode } from '../TileshareCreate';
+
+vi.mock('@/core/theme/ThemeProvider', () => ({
+	useTheme: () => ({ isDarkMode: false, toggleTheme: vi.fn() }),
+}));
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('TileshareCreate', () => {
+	it('renders the single-mode copy, shared fields and the share-to field', () => {
+		render(<TileshareCreate mode={TileshareMode.Single} onBack={vi.fn()} />);
+
+		expect(screen.getByText('tilesharedemo.dashboard.create.single.title')).toBeInTheDocument();
+		expect(
+			screen.getByText('tilesharedemo.dashboard.create.single.description')
+		).toBeInTheDocument();
+		expect(
+			screen.getByText('tilesharedemo.dashboard.create.single.submit')
+		).toBeInTheDocument();
+		expect(
+			screen.getByPlaceholderText('tilesharedemo.dashboard.create.fields.name.placeholder')
+		).toBeInTheDocument();
+		expect(
+			screen.getByPlaceholderText('tilesharedemo.dashboard.create.shareTo.placeholder')
+		).toBeInTheDocument();
+	});
+
+	it('renders the multi-mode copy and omits the share-to field', () => {
+		render(<TileshareCreate mode={TileshareMode.Multi} onBack={vi.fn()} />);
+
+		expect(screen.getByText('tilesharedemo.dashboard.create.multi.title')).toBeInTheDocument();
+		expect(
+			screen.getByText('tilesharedemo.dashboard.create.multi.description')
+		).toBeInTheDocument();
+		expect(screen.getByText('tilesharedemo.dashboard.create.multi.submit')).toBeInTheDocument();
+		expect(
+			screen.getByPlaceholderText('tilesharedemo.dashboard.create.fields.name.placeholder')
+		).toBeInTheDocument();
+		expect(
+			screen.queryByPlaceholderText('tilesharedemo.dashboard.create.shareTo.placeholder')
+		).not.toBeInTheDocument();
+	});
+
+	it('calls onBack from both the back button and the cancel button', async () => {
+		const user = setupUser();
+		const onBack = vi.fn();
+		render(<TileshareCreate mode={TileshareMode.Single} onBack={onBack} />);
+
+		await user.click(screen.getByText('tilesharedemo.dashboard.create.back'));
+		await user.click(screen.getByText('tilesharedemo.dashboard.create.buttons.cancel'));
+
+		expect(onBack).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/components/tileshare/__tests__/TileshareToolbar.test.tsx
+++ b/src/components/tileshare/__tests__/TileshareToolbar.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@/test/test-utils';
+import { setupUser } from '@/test/test-utils';
+import TileshareToolbar from '../TileshareToolbar';
+
+vi.mock('@/core/theme/ThemeProvider', () => ({
+	useTheme: () => ({ isDarkMode: false, toggleTheme: vi.fn() }),
+}));
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('TileshareToolbar', () => {
+	it('renders the avatar cluster and greeting for the given user', () => {
+		render(
+			<TileshareToolbar
+				user={{ name: 'Alice Adams', email: 'alice@example.com' }}
+				onSelectSingle={vi.fn()}
+				onSelectMulti={vi.fn()}
+			/>
+		);
+		expect(screen.getByText('AA')).toBeInTheDocument();
+		expect(screen.getByText('tilesharedemo.dashboard.toolbar.welcome')).toBeInTheDocument();
+		expect(screen.getByText('Alice Adams')).toBeInTheDocument();
+	});
+
+	it('opens the create selection dropdown and triggers the chosen option', async () => {
+		const user = setupUser();
+		const onSelectSingle = vi.fn();
+		const onSelectMulti = vi.fn();
+		render(
+			<TileshareToolbar
+				user={{ name: 'Alice Adams', email: null }}
+				onSelectSingle={onSelectSingle}
+				onSelectMulti={onSelectMulti}
+			/>
+		);
+
+		expect(
+			screen.queryByText('tilesharedemo.dashboard.createSelection.single.label')
+		).not.toBeInTheDocument();
+
+		await user.click(
+			screen.getByRole('button', { name: 'tilesharedemo.dashboard.toolbar.create' })
+		);
+
+		expect(
+			screen.getByText('tilesharedemo.dashboard.createSelection.single.label')
+		).toBeInTheDocument();
+		expect(
+			screen.getByText('tilesharedemo.dashboard.createSelection.multi.label')
+		).toBeInTheDocument();
+
+		await user.click(screen.getByText('tilesharedemo.dashboard.createSelection.multi.label'));
+
+		expect(onSelectMulti).toHaveBeenCalledTimes(1);
+		expect(onSelectSingle).not.toHaveBeenCalled();
+		expect(
+			screen.queryByText('tilesharedemo.dashboard.createSelection.single.label')
+		).not.toBeInTheDocument();
+	});
+});

--- a/src/core/common/components/TagInput.tsx
+++ b/src/core/common/components/TagInput.tsx
@@ -1,0 +1,170 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { Plus, X } from 'lucide-react';
+import Input, { BaseInputProps } from './input';
+
+type TagInputProps = {
+	/** The committed tags — the single source of truth. */
+	value: string[];
+	/** Called with the next tag list on add or remove. */
+	onChange: (next: string[]) => void;
+	placeholder?: string;
+	/** Accessible label for the add (+) button. */
+	addLabel?: string;
+	/** Builds the accessible label for a chip's remove (x) button. */
+	removeLabel?: (value: string) => string;
+	disabled?: boolean;
+	sized?: 'small' | 'medium' | 'large';
+	/** Extra props forwarded to the underlying Input (e.g. name, aria attributes). */
+	inputProps?: Omit<
+		BaseInputProps,
+		'value' | 'onChange' | 'onKeyDown' | 'append' | 'disabled' | 'sized' | 'placeholder'
+	>;
+};
+
+/**
+ * A theme-aware tag/chip input. The caller owns the committed list via
+ * `value`/`onChange`; only the in-progress text draft is internal. A tag is
+ * committed on Enter, comma, or the add button, and removed via its chip.
+ * Empty and duplicate values are ignored.
+ */
+const TagInput: React.FC<TagInputProps> = ({
+	value,
+	onChange,
+	placeholder,
+	addLabel,
+	removeLabel,
+	disabled = false,
+	sized = 'medium',
+	inputProps,
+}) => {
+	const [draft, setDraft] = useState('');
+
+	const commit = (raw: string) => {
+		if (disabled) return;
+		const trimmed = raw.trim();
+		if (trimmed && !value.includes(trimmed)) {
+			onChange([...value, trimmed]);
+		}
+		setDraft('');
+	};
+
+	const remove = (tag: string) => {
+		if (disabled) return;
+		onChange(value.filter((t) => t !== tag));
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === 'Enter' || e.key === ',') {
+			e.preventDefault();
+			commit(draft);
+		} else if (e.key === 'Backspace' && !draft && value.length) {
+			onChange(value.slice(0, -1));
+		}
+	};
+
+	return (
+		<Container>
+			<Input
+				{...inputProps}
+				sized={sized}
+				disabled={disabled}
+				value={draft}
+				placeholder={placeholder}
+				onChange={(e) => setDraft(e.target.value)}
+				onKeyDown={handleKeyDown}
+				append={
+					<AddButton
+						type="button"
+						aria-label={addLabel}
+						disabled={disabled}
+						onClick={() => commit(draft)}
+					>
+						<Plus size={16} />
+					</AddButton>
+				}
+			/>
+			{value.length > 0 && (
+				<TagList>
+					{value.map((tag) => (
+						<Tag key={tag}>
+							<span>{tag}</span>
+							<Remove
+								type="button"
+								aria-label={removeLabel?.(tag)}
+								disabled={disabled}
+								onClick={() => remove(tag)}
+							>
+								<X size={14} />
+							</Remove>
+						</Tag>
+					))}
+				</TagList>
+			)}
+		</Container>
+	);
+};
+
+const Container = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	width: 100%;
+`;
+
+const AddButton = styled.button`
+	height: 28px;
+	width: 28px;
+	color: ${({ theme }) => theme.colors.tagInput.addText};
+	background-color: ${({ theme }) => theme.colors.tagInput.addBg};
+	border-radius: ${({ theme }) => theme.borderRadius.medium};
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	&:hover {
+		background-color: ${({ theme }) => theme.colors.tagInput.addBgHover};
+	}
+
+	&:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+`;
+
+const TagList = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+`;
+
+const Tag = styled.span`
+	display: inline-flex;
+	align-items: center;
+	gap: 0.375rem;
+	padding: 0.25rem 0.375rem 0.25rem 0.625rem;
+	border-radius: ${({ theme }) => theme.borderRadius.large};
+	border: 1px solid ${({ theme }) => theme.colors.tagInput.chipBorder};
+	background-color: ${({ theme }) => theme.colors.tagInput.chipBg};
+	color: ${({ theme }) => theme.colors.tagInput.chipText};
+	font-family: ${({ theme }) => theme.typography.fontFamily.inter};
+	font-size: ${({ theme }) => theme.typography.fontSize.sm};
+`;
+
+const Remove = styled.button`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: ${({ theme }) => theme.colors.tagInput.remove};
+	transition: color 0.2s ease;
+
+	&:hover {
+		color: ${({ theme }) => theme.colors.tagInput.removeHover};
+	}
+
+	&:disabled {
+		cursor: not-allowed;
+	}
+`;
+
+export default TagInput;

--- a/src/core/common/components/__tests__/TagInput.test.tsx
+++ b/src/core/common/components/__tests__/TagInput.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@/core/theme/ThemeProvider';
+import TagInput from '@/core/common/components/TagInput';
+
+const renderWithTheme = (ui: React.ReactElement) =>
+	render(<ThemeProvider defaultTheme="dark">{ui}</ThemeProvider>);
+
+describe('TagInput', () => {
+	describe('Rendering', () => {
+		it('renders the placeholder', () => {
+			renderWithTheme(<TagInput value={[]} onChange={vi.fn()} placeholder="Add recipient" />);
+			expect(screen.getByPlaceholderText('Add recipient')).toBeInTheDocument();
+		});
+
+		it('renders a chip for each value', () => {
+			renderWithTheme(<TagInput value={['a@x.com', 'b@x.com']} onChange={vi.fn()} />);
+			expect(screen.getByText('a@x.com')).toBeInTheDocument();
+			expect(screen.getByText('b@x.com')).toBeInTheDocument();
+		});
+
+		it('renders no chips when empty', () => {
+			renderWithTheme(
+				<TagInput value={[]} onChange={vi.fn()} removeLabel={(v) => `Remove ${v}`} />
+			);
+			expect(screen.queryByLabelText(/Remove/)).not.toBeInTheDocument();
+		});
+	});
+
+	describe('Adding', () => {
+		it('commits the draft on Enter with the appended value', () => {
+			const onChange = vi.fn();
+			renderWithTheme(<TagInput value={[]} onChange={onChange} placeholder="Add" />);
+			const input = screen.getByPlaceholderText('Add');
+			fireEvent.change(input, { target: { value: 'a@x.com' } });
+			fireEvent.keyDown(input, { key: 'Enter' });
+			expect(onChange).toHaveBeenCalledWith(['a@x.com']);
+		});
+
+		it('commits the draft on comma', () => {
+			const onChange = vi.fn();
+			renderWithTheme(<TagInput value={['a@x.com']} onChange={onChange} placeholder="Add" />);
+			const input = screen.getByPlaceholderText('Add');
+			fireEvent.change(input, { target: { value: 'b@x.com' } });
+			fireEvent.keyDown(input, { key: ',' });
+			expect(onChange).toHaveBeenCalledWith(['a@x.com', 'b@x.com']);
+		});
+
+		it('commits the draft when the add button is clicked', () => {
+			const onChange = vi.fn();
+			renderWithTheme(
+				<TagInput
+					value={[]}
+					onChange={onChange}
+					placeholder="Add"
+					addLabel="Add recipient"
+				/>
+			);
+			fireEvent.change(screen.getByPlaceholderText('Add'), {
+				target: { value: 'a@x.com' },
+			});
+			fireEvent.click(screen.getByLabelText('Add recipient'));
+			expect(onChange).toHaveBeenCalledWith(['a@x.com']);
+		});
+
+		it('trims whitespace before committing', () => {
+			const onChange = vi.fn();
+			renderWithTheme(<TagInput value={[]} onChange={onChange} placeholder="Add" />);
+			const input = screen.getByPlaceholderText('Add');
+			fireEvent.change(input, { target: { value: '  a@x.com  ' } });
+			fireEvent.keyDown(input, { key: 'Enter' });
+			expect(onChange).toHaveBeenCalledWith(['a@x.com']);
+		});
+
+		it('ignores empty and whitespace-only input', () => {
+			const onChange = vi.fn();
+			renderWithTheme(<TagInput value={[]} onChange={onChange} placeholder="Add" />);
+			const input = screen.getByPlaceholderText('Add');
+			fireEvent.change(input, { target: { value: '   ' } });
+			fireEvent.keyDown(input, { key: 'Enter' });
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it('ignores duplicate values', () => {
+			const onChange = vi.fn();
+			renderWithTheme(<TagInput value={['a@x.com']} onChange={onChange} placeholder="Add" />);
+			const input = screen.getByPlaceholderText('Add');
+			fireEvent.change(input, { target: { value: 'a@x.com' } });
+			fireEvent.keyDown(input, { key: 'Enter' });
+			expect(onChange).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Removing', () => {
+		it('removes a chip via its remove button', () => {
+			const onChange = vi.fn();
+			renderWithTheme(
+				<TagInput
+					value={['a@x.com', 'b@x.com']}
+					onChange={onChange}
+					removeLabel={(v) => `Remove ${v}`}
+				/>
+			);
+			fireEvent.click(screen.getByLabelText('Remove a@x.com'));
+			expect(onChange).toHaveBeenCalledWith(['b@x.com']);
+		});
+
+		it('removes the last tag on Backspace when the draft is empty', () => {
+			const onChange = vi.fn();
+			renderWithTheme(
+				<TagInput value={['a@x.com', 'b@x.com']} onChange={onChange} placeholder="Add" />
+			);
+			fireEvent.keyDown(screen.getByPlaceholderText('Add'), { key: 'Backspace' });
+			expect(onChange).toHaveBeenCalledWith(['a@x.com']);
+		});
+	});
+
+	describe('Disabled state', () => {
+		it('disables the add and remove buttons', () => {
+			renderWithTheme(
+				<TagInput
+					value={['a@x.com']}
+					onChange={vi.fn()}
+					addLabel="Add recipient"
+					removeLabel={(v) => `Remove ${v}`}
+					disabled
+				/>
+			);
+			expect(screen.getByLabelText('Add recipient')).toBeDisabled();
+			expect(screen.getByLabelText('Remove a@x.com')).toBeDisabled();
+		});
+	});
+});

--- a/src/core/common/components/input.tsx
+++ b/src/core/common/components/input.tsx
@@ -271,7 +271,6 @@ const StyledInput = styled.input<StyledInputProps>`
 	font-weight: ${palette.typography.fontWeight.normal};
 	line-height: 1;
 	color: ${({ theme }) => theme.colors.input.text};
-	height: 100%;
 
 	padding-left: calc(
 		${(props) => (props.$sized === 'small' ? palette.space.small : palette.space.medium)} -
@@ -314,12 +313,12 @@ const StyledTextarea = styled.textarea<StyledInputProps>`
 
 	/* Fix vertical alignment for the textarea */
 	padding: 0;
-	padding-top: ${(props) =>
+	padding-block: ${(props) =>
 		props.$sized === 'small'
-			? `calc(${palette.inputHeights.small} / 2 - 0.75rem)`
+			? `calc(${palette.inputHeights.small} / 2 - 0.75rem + 0.375rem)`
 			: props.$sized === 'medium'
-				? `calc(${palette.inputHeights.medium} / 2 - 0.875rem)`
-				: `calc(${palette.inputHeights.large} / 2 - 1rem)`};
+				? `calc(${palette.inputHeights.medium} / 2 - 0.875rem + 0.5rem)`
+				: `calc(${palette.inputHeights.large} / 2 - 1rem + 0.5rem)`};
 	padding-inline: calc(
 		${(props) => (props.$sized === 'small' ? palette.space.small : palette.space.medium)} - 6px
 	);

--- a/src/core/common/components/input.tsx
+++ b/src/core/common/components/input.tsx
@@ -190,6 +190,14 @@ const StyledInputWrapper = styled.div<StyledInputProps>`
 				: props.$sized === 'medium'
 					? palette.inputHeights.medium
 					: palette.inputHeights.large};
+	min-height: ${(props) =>
+		props.$height
+			? `${props.$height}px`
+			: props.$sized === 'small'
+				? palette.inputHeights.small
+				: props.$sized === 'medium'
+					? palette.inputHeights.medium
+					: palette.inputHeights.large};
 
 	${(props) =>
 		props.$bordergradient &&

--- a/src/core/common/types/tileshare.ts
+++ b/src/core/common/types/tileshare.ts
@@ -95,6 +95,58 @@ export type DeleteTileShareClusterParams = {
 
 export type DeleteTileShareClusterResponse = ApiResponse<unknown>;
 
+export type AddressDataModel = {
+	Address: string;
+	Description?: string;
+	AddressIsVerified: boolean;
+};
+
+export type ContactModel = {
+	Id?: string;
+	FirstName?: string;
+	LastName?: string;
+	Email?: string;
+	PhoneNumber?: string;
+};
+
+export type CreateTileShareClusterParams = {
+	UserName: string | null;
+	TimeZone: string | null;
+	TimeZoneOffset: number | null;
+	Name: string;
+	IsMultiTilette: boolean;
+	IncludeMe: boolean;
+	/** epoch ms, optional earliest-start bound */
+	StartTime?: number;
+	/** epoch ms, the deadline */
+	EndTime?: number;
+	DurationInMs?: number;
+	Notes?: string;
+	AddressData?: AddressDataModel;
+	/** Must never be null — send [] when empty (backend dereferences without a null check). */
+	Contacts: ContactModel[];
+};
+
+/**
+ * Create returns the cluster object directly as `Content` (from
+ * `TileShareCluster.ToJson`) — unlike the GET-by-id path, which wraps it as
+ * `{ cluster }`. Field casing is best-effort until confirmed against a real body.
+ */
+export type CreateTileShareClusterResponse = ApiResponse<TileShareCluster>;
+
+export enum TileshareMode {
+	Single = 'single',
+	Multi = 'multi',
+}
+
+export type TileshareFormState = {
+	name: string;
+	deadline: string;
+	location: string;
+	note: string;
+	recipients: string[];
+};
+
 export type SortOrder = 'asc' | 'desc';
 
 /** Default server page size (ServerContants.batchPageSize). */

--- a/src/core/theme/dark.ts
+++ b/src/core/theme/dark.ts
@@ -146,6 +146,17 @@ export const darkTheme: AppTheme = {
 			base: palette.colors.gray[800],
 			highlight: palette.colors.gray[600],
 		},
+		// Tag input colors
+		tagInput: {
+			chipBg: palette.colors.gray[900],
+			chipBorder: palette.colors.gray[800],
+			chipText: palette.colors.gray[200],
+			remove: palette.colors.gray[400],
+			removeHover: palette.colors.gray[100],
+			addBg: palette.colors.brand[500],
+			addBgHover: palette.colors.brand[600],
+			addText: palette.colors.white,
+		},
 		// hues
 		brand: palette.colors.brand,
 		gray: palette.colors.gray,

--- a/src/core/theme/light.ts
+++ b/src/core/theme/light.ts
@@ -146,6 +146,17 @@ export const lightTheme: AppTheme = {
 			base: palette.colors.gray[200],
 			highlight: palette.colors.gray[50],
 		},
+		// Tag input colors
+		tagInput: {
+			chipBg: palette.colors.gray[100],
+			chipBorder: palette.colors.gray[200],
+			chipText: palette.colors.gray[700],
+			remove: palette.colors.gray[500],
+			removeHover: palette.colors.gray[900],
+			addBg: palette.colors.brand[500],
+			addBgHover: palette.colors.brand[600],
+			addText: palette.colors.white,
+		},
 		// hues
 		brand: palette.colors.brand,
 		gray: palette.colors.gray,

--- a/src/core/theme/types.ts
+++ b/src/core/theme/types.ts
@@ -175,6 +175,17 @@ export type AppTheme = {
 			base: string;
 			highlight: string;
 		};
+		// Tag input colors
+		tagInput: {
+			chipBg: string;
+			chipBorder: string;
+			chipText: string;
+			remove: string;
+			removeHover: string;
+			addBg: string;
+			addBgHover: string;
+			addText: string;
+		};
 		// Utility colors
 		white: string;
 		black: string;

--- a/src/core/ui/types.ts
+++ b/src/core/ui/types.ts
@@ -29,6 +29,7 @@ export enum NotificationAction {
 	Revise = 'revise',
 	Procrastinate = 'procrastinate',
 	ProcrastinateAll = 'procrastinate-all',
+	CreateTileshare = 'create-tileshare',
 }
 
 /** Build a deterministic notification ID from an action and entity ID */

--- a/src/core/util/__tests__/contact.test.ts
+++ b/src/core/util/__tests__/contact.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { classifyContact, isValidRecipient, normalizePhoneNumber } from '../contact';
+
+describe('classifyContact', () => {
+	it('classifies an email address as email', () => {
+		expect(classifyContact('jane@example.com')).toBe('email');
+	});
+
+	it('classifies a bare number as phone', () => {
+		expect(classifyContact('3035551212')).toBe('phone');
+	});
+
+	it('classifies a number with a leading + as phone', () => {
+		expect(classifyContact('+13035551212')).toBe('phone');
+	});
+
+	it('classifies a formatted number as phone', () => {
+		expect(classifyContact('+1 (303) 555-1212')).toBe('phone');
+	});
+
+	it('classifies an alphanumeric value as email', () => {
+		expect(classifyContact('303-abc')).toBe('email');
+	});
+});
+
+describe('isValidRecipient', () => {
+	it('validates emails through the email path', () => {
+		expect(isValidRecipient('jane@example.com')).toBe(true);
+		expect(isValidRecipient('nope')).toBe(false);
+	});
+
+	it('validates phone numbers through the phone path', () => {
+		expect(isValidRecipient('3035551212')).toBe(true);
+		expect(isValidRecipient('12345')).toBe(false);
+	});
+});
+
+describe('normalizePhoneNumber', () => {
+	it('prepends the default calling code when there is no +', () => {
+		expect(normalizePhoneNumber('3035551212', '1')).toBe('+13035551212');
+	});
+
+	it('preserves an existing + area code', () => {
+		expect(normalizePhoneNumber('+443035551212', '1')).toBe('+443035551212');
+	});
+
+	it('strips formatting characters', () => {
+		expect(normalizePhoneNumber('(303) 555-1212', '1')).toBe('+13035551212');
+	});
+
+	it('uses a non-US default calling code', () => {
+		expect(normalizePhoneNumber('8031234567', '234')).toBe('+2348031234567');
+	});
+
+	it('falls back to the default country code when given a blank code', () => {
+		expect(normalizePhoneNumber('3035551212', '')).toBe('+13035551212');
+	});
+});

--- a/src/core/util/__tests__/validation.test.ts
+++ b/src/core/util/__tests__/validation.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { validateEmail, validatePhone } from '../validation';
+
+describe('validateEmail', () => {
+	it('accepts a well-formed address', () => {
+		expect(validateEmail('jane@example.com')).toBe(true);
+	});
+
+	it('rejects a malformed address', () => {
+		expect(validateEmail('not-an-email')).toBe(false);
+		expect(validateEmail('jane@')).toBe(false);
+	});
+});
+
+describe('validatePhone', () => {
+	it('rejects numbers with too few digits', () => {
+		expect(validatePhone('12345')).toBe(false);
+	});
+
+	it('accepts a bare national number (area code optional)', () => {
+		expect(validatePhone('3035551212')).toBe(true);
+	});
+
+	it('accepts a number with a country code', () => {
+		expect(validatePhone('+13035551212')).toBe(true);
+	});
+
+	it('ignores formatting characters when counting digits', () => {
+		expect(validatePhone('+1 (303) 555-1212')).toBe(true);
+	});
+
+	it('rejects numbers with more than 15 digits', () => {
+		expect(validatePhone('1234567890123456')).toBe(false);
+	});
+});

--- a/src/core/util/contact.ts
+++ b/src/core/util/contact.ts
@@ -1,0 +1,34 @@
+/**
+ * Contact channel utilities — decide whether a raw share-to value is an email
+ * or a phone number, validate it, and normalize phone numbers for the API.
+ */
+import { DEFAULT_COUNTRY_CODE } from '@/core/constants/countryCodes';
+import { validateEmail, validatePhone } from './validation';
+
+export type ContactChannel = 'email' | 'phone';
+
+/** All digits with optional grouping/formatting and an optional leading '+'. */
+const PHONE_LIKE = /^\+?[\d\s().-]+$/;
+
+/**
+ * A value made up of digits (optionally a leading '+' for the area code) is a
+ * phone number; anything else is treated as an email.
+ */
+export const classifyContact = (value: string): ContactChannel =>
+	PHONE_LIKE.test(value.trim()) ? 'phone' : 'email';
+
+/** Validates a recipient against the rules for its detected channel. */
+export const isValidRecipient = (value: string): boolean =>
+	classifyContact(value) === 'phone' ? validatePhone(value) : validateEmail(value.trim());
+
+/**
+ * Returns the phone number in `+<callingCode><digits>` form. A value that
+ * already carries a '+' area code keeps it; one without gets `defaultCallingCode`
+ * (a bare dial code like "1") prepended.
+ */
+export const normalizePhoneNumber = (value: string, defaultCallingCode: string): string => {
+	const digits = value.replace(/\D/g, '');
+	if (value.trim().startsWith('+')) return `+${digits}`;
+	const cc = defaultCallingCode.replace(/\D/g, '') || String(DEFAULT_COUNTRY_CODE.code);
+	return `+${cc}${digits}`;
+};

--- a/src/core/util/validation.ts
+++ b/src/core/util/validation.ts
@@ -11,3 +11,14 @@ export const validateEmail = (email: string): boolean => {
 	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 	return emailRegex.test(email);
 };
+
+/**
+ * Validates a phone number by its digit count (E.164 allows up to 15 digits).
+ * The area/country code is optional, so a bare national number also passes.
+ * @param phone - The phone string to validate (may contain +, spaces, dashes)
+ * @returns true if the number has a plausible number of digits
+ */
+export const validatePhone = (phone: string): boolean => {
+	const digits = phone.replace(/\D/g, '');
+	return digits.length >= 7 && digits.length <= 15;
+};

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1576,8 +1576,8 @@
 					}
 				},
 				"shareTo": {
-					"label": "Share to :",
-					"placeholder": "email address/phone number",
+					"label": "Share to:",
+					"placeholder": "email address / phone number (Enter to select)",
 					"add": "Add recipient",
 					"remove": "Remove {{recipient}}"
 				},
@@ -1587,12 +1587,16 @@
 				"validation": {
 					"nameRequired": "Please name your task",
 					"deadlineRequired": "Please add a deadline",
+					"recipientRequired": "Please add at least one recipient",
 					"invalidRecipient": "{{recipient}} is not a valid email or phone number"
 				},
 				"toast": {
 					"creating": "Creating tileshare…",
-					"success": "Tileshare created",
 					"error": "Couldn't create tileshare. Please try again."
+				},
+				"success": {
+					"message": "Your tileshare \"{{name}}\" has been created.",
+					"view": "View tileshare"
 				}
 			},
 			"filter": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1559,7 +1559,7 @@
 				"multi": {
 					"title": "Create a multi tileshare",
 					"description": "Create and share a variety of tasks in one project. Once colleagues accept, we'll add it to their schedule.",
-					"submit": "Continue"
+					"submit": "Create multi tileshare"
 				},
 				"fields": {
 					"name": {
@@ -1569,19 +1569,30 @@
 						"placeholder": "Add a deadline"
 					},
 					"location": {
-						"placeholder": "Add a location? (Skip if not needed)"
+						"placeholder": "Add a location (optional)"
 					},
 					"note": {
-						"placeholder": "Add a note"
+						"placeholder": "Add a note (optional)"
 					}
 				},
 				"shareTo": {
 					"label": "Share to :",
 					"placeholder": "email address/phone number",
-					"add": "Add recipient"
+					"add": "Add recipient",
+					"remove": "Remove {{recipient}}"
 				},
 				"buttons": {
 					"cancel": "Cancel"
+				},
+				"validation": {
+					"nameRequired": "Please name your task",
+					"deadlineRequired": "Please add a deadline",
+					"invalidRecipient": "{{recipient}} is not a valid email or phone number"
+				},
+				"toast": {
+					"creating": "Creating tileshare…",
+					"success": "Tileshare created",
+					"error": "Couldn't create tileshare. Please try again."
 				}
 			},
 			"filter": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1868,50 +1868,5 @@
 				}
 			}
 		}
-	},
-	"tilesharedemo": {
-		"dashboard": {
-			"title": "Tileshare",
-			"nav": {
-				"active": "Active",
-				"sent": "Sent",
-				"received": "Received ({{count}})"
-			},
-			"filter": {
-				"all": "All",
-				"inProgress": "In Progress"
-			}
-		},
-		"card": {
-			"progress": "Progress",
-			"dueOn": "Due on:",
-			"dueBy": "Due by:",
-			"multiTileshare": "Multi tileshare",
-			"tileshare": "Tileshare"
-		},
-		"active": {
-			"title": "Active",
-			"empty": "No active tileshares",
-			"emptyFiltered": "No in-progress items in your active tileshares"
-		},
-		"sent": {
-			"title": "Sent",
-			"empty": "You haven't sent any tileshares yet",
-			"emptyFiltered": "No in-progress items in your sent tileshares"
-		},
-		"received": {
-			"title": "Received",
-			"empty": "You haven't received any tileshares yet",
-			"emptyFiltered": "No in-progress items in your received tileshares"
-		},
-		"tileshareDetail": {
-			"title": "Tileshare Detail"
-		},
-		"tiletteDetail": {
-			"title": "Tilette Detail"
-		},
-		"invite": {
-			"title": "Invite"
-		}
 	}
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1535,6 +1535,20 @@
 				"sent": "Sent",
 				"received": "Received ({{count}})"
 			},
+			"toolbar": {
+				"welcome": "Welcome to your Tileshare Dashboard",
+				"create": "Create tileshare"
+			},
+			"createSelection": {
+				"single": {
+					"label": "Single Tileshare",
+					"description": "A single task with your colleagues."
+				},
+				"multi": {
+					"label": "Multi Tileshare",
+					"description": "A variety of tasks in one project."
+				}
+			},
 			"filter": {
 				"all": "All",
 				"inProgress": "In Progress"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1549,6 +1549,41 @@
 					"description": "A variety of tasks in one project."
 				}
 			},
+			"create": {
+				"back": "Back to tileshare",
+				"single": {
+					"title": "Create a single tileshare",
+					"description": "Create and share a single task with your colleagues. Once they accept, we'll add it to their schedule.",
+					"submit": "Create single tileshare"
+				},
+				"multi": {
+					"title": "Create a multi tileshare",
+					"description": "Create and share a variety of tasks in one project. Once colleagues accept, we'll add it to their schedule.",
+					"submit": "Continue"
+				},
+				"fields": {
+					"name": {
+						"placeholder": "Name your task"
+					},
+					"deadline": {
+						"placeholder": "Add a deadline"
+					},
+					"location": {
+						"placeholder": "Add a location? (Skip if not needed)"
+					},
+					"note": {
+						"placeholder": "Add a note"
+					}
+				},
+				"shareTo": {
+					"label": "Share to :",
+					"placeholder": "email address/phone number",
+					"add": "Add recipient"
+				},
+				"buttons": {
+					"cancel": "Cancel"
+				}
+			},
 			"filter": {
 				"all": "All",
 				"inProgress": "In Progress"

--- a/src/pages/app/tileshare/TileShareDashboard.tsx
+++ b/src/pages/app/tileshare/TileShareDashboard.tsx
@@ -4,8 +4,10 @@ import { useTranslation } from 'react-i18next';
 import { ArrowUpRight, CalendarCheck2 } from 'lucide-react';
 import { CalendarUIProvider } from '@/core/common/components/calendar/calendar-ui.provider';
 import Tabs, { TabItem } from '@/core/common/components/Tabs';
+import TileshareToolbar from '@/components/tileshare/TileshareToolbar';
 import { Outlet, useLocation, useNavigate } from 'react-router';
 import { Routes } from '@/core/constants/routes';
+import { useAuth } from '@/core/auth/useAuth';
 
 export enum TileshareTab {
 	Active = 'active',
@@ -16,6 +18,7 @@ const TileshareDashboardPage: React.FC = () => {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const { pathname } = useLocation();
+	const { user } = useAuth();
 	const [activeTab, setActiveTab] = useState<TileshareTab>(TileshareTab.Active);
 
 	useEffect(() => {
@@ -51,9 +54,17 @@ const TileshareDashboardPage: React.FC = () => {
 		if (tabRoutes[id]) navigate(tabRoutes[id]);
 	};
 
+	const handleSelectSingle = () => {};
+	const handleSelectMulti = () => {};
+
 	return (
 		<Container>
 			<CalendarUIProvider>
+				<StyledToolbar
+					user={{ name: user?.fullName ?? null, email: user?.email ?? null }}
+					onSelectSingle={handleSelectSingle}
+					onSelectMulti={handleSelectMulti}
+				/>
 				<Header>
 					<Tabs
 						tabs={tabs}
@@ -77,6 +88,10 @@ const Container = styled.div`
 	background-color: ${(props) => props.theme.colors.background.page};
 	overflow-y: scroll;
 	isolation: isolate;
+`;
+
+const StyledToolbar = styled(TileshareToolbar)`
+	padding: 1rem 1.5rem 0;
 `;
 
 const Header = styled.header`

--- a/src/pages/app/tileshare/TileShareDashboard.tsx
+++ b/src/pages/app/tileshare/TileShareDashboard.tsx
@@ -63,7 +63,13 @@ const TileshareDashboardPage: React.FC = () => {
 		<Container>
 			<CalendarUIProvider>
 				{createMode ? (
-					<TileshareCreate mode={createMode} onBack={() => setCreateMode(null)} />
+					<TileshareCreate
+						mode={createMode}
+						onBack={() => {
+							setCreateMode(null);
+							navigate(Routes.Tileshare.sent);
+						}}
+					/>
 				) : (
 					<>
 						<StyledToolbar

--- a/src/pages/app/tileshare/TileShareDashboard.tsx
+++ b/src/pages/app/tileshare/TileShareDashboard.tsx
@@ -5,6 +5,7 @@ import { ArrowUpRight, CalendarCheck2 } from 'lucide-react';
 import { CalendarUIProvider } from '@/core/common/components/calendar/calendar-ui.provider';
 import Tabs, { TabItem } from '@/core/common/components/Tabs';
 import TileshareToolbar from '@/components/tileshare/TileshareToolbar';
+import TileshareCreate, { TileshareMode } from '@/components/tileshare/TileshareCreate';
 import { Outlet, useLocation, useNavigate } from 'react-router';
 import { Routes } from '@/core/constants/routes';
 import { useAuth } from '@/core/auth/useAuth';
@@ -20,6 +21,7 @@ const TileshareDashboardPage: React.FC = () => {
 	const { pathname } = useLocation();
 	const { user } = useAuth();
 	const [activeTab, setActiveTab] = useState<TileshareTab>(TileshareTab.Active);
+	const [createMode, setCreateMode] = useState<TileshareMode | null>(null);
 
 	useEffect(() => {
 		if (pathname.endsWith(Routes.Tileshare.active)) {
@@ -54,29 +56,35 @@ const TileshareDashboardPage: React.FC = () => {
 		if (tabRoutes[id]) navigate(tabRoutes[id]);
 	};
 
-	const handleSelectSingle = () => {};
-	const handleSelectMulti = () => {};
+	const handleSelectSingle = () => setCreateMode(TileshareMode.Single);
+	const handleSelectMulti = () => setCreateMode(TileshareMode.Multi);
 
 	return (
 		<Container>
 			<CalendarUIProvider>
-				<StyledToolbar
-					user={{ name: user?.fullName ?? null, email: user?.email ?? null }}
-					onSelectSingle={handleSelectSingle}
-					onSelectMulti={handleSelectMulti}
-				/>
-				<Header>
-					<Tabs
-						tabs={tabs}
-						value={activeTab}
-						onChange={handleTabChange}
-						aria-label={t('tilesharedemo.dashboard.title')}
-						stretch
-					/>
-				</Header>
-				<Main>
-					<Outlet />
-				</Main>
+				{createMode ? (
+					<TileshareCreate mode={createMode} onBack={() => setCreateMode(null)} />
+				) : (
+					<>
+						<StyledToolbar
+							user={{ name: user?.fullName ?? null, email: user?.email ?? null }}
+							onSelectSingle={handleSelectSingle}
+							onSelectMulti={handleSelectMulti}
+						/>
+						<Header>
+							<Tabs
+								tabs={tabs}
+								value={activeTab}
+								onChange={handleTabChange}
+								aria-label={t('tilesharedemo.dashboard.title')}
+								stretch
+							/>
+						</Header>
+						<Main>
+							<Outlet />
+						</Main>
+					</>
+				)}
 			</CalendarUIProvider>
 		</Container>
 	);
@@ -91,14 +99,15 @@ const Container = styled.div`
 `;
 
 const StyledToolbar = styled(TileshareToolbar)`
-	padding: 1rem 1.5rem 0;
+	padding: 1.5rem;
+	border-bottom: 1px solid ${({ theme }) => theme.colors.border.default};
 `;
 
 const Header = styled.header`
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	padding: 1rem 1.5rem;
+	padding: 1.5rem 1.5rem 1rem;
 `;
 
 const Main = styled.main`

--- a/src/services/__tests__/tileshareService.test.ts
+++ b/src/services/__tests__/tileshareService.test.ts
@@ -1,7 +1,8 @@
 import { vi } from 'vitest';
-import TileshareService from '../tileshareService';
+import TileshareService, { toCreateClusterParams } from '../tileshareService';
 import type { TileshareApi } from '@/api/tileshareApi';
-import { InvitationStatus } from '@/core/common/types/tileshare';
+import { InvitationStatus, TileshareFormState, TileshareMode } from '@/core/common/types/tileshare';
+import { dateTimeToUnix } from '@/core/util/eventTimeConversion';
 
 const mockCreator = {
 	id: 'user-1',
@@ -132,6 +133,177 @@ describe('TileshareService', () => {
 
 			const service = new TileshareService(apiMock);
 			await expect(service.getDesignatedTiles()).rejects.toThrow();
+		});
+	});
+
+	describe('toCreateClusterParams', () => {
+		const ctx = {
+			userName: 'test@example.com',
+			timeZone: 'UTC',
+			timeZoneOffset: 0,
+			defaultCallingCode: '1',
+		};
+		const baseForm: TileshareFormState = {
+			name: '  Finish taxes  ',
+			deadline: '2026-08-01',
+			location: '',
+			note: '',
+			recipients: [],
+		};
+
+		it('maps single-mode form to a flat payload with trimmed fields', () => {
+			const params = toCreateClusterParams(baseForm, TileshareMode.Single, ctx);
+
+			expect(params.Name).toBe('Finish taxes');
+			expect(params.IsMultiTilette).toBe(false);
+			expect(params.IncludeMe).toBe(true);
+			expect(params.UserName).toBe('test@example.com');
+			expect(params.TimeZone).toBe('UTC');
+			expect(params.TimeZoneOffset).toBe(0);
+			expect(params.DurationInMs).toBeGreaterThan(0);
+		});
+
+		it('sets IsMultiTilette true for multi mode', () => {
+			const params = toCreateClusterParams(baseForm, TileshareMode.Multi, ctx);
+			expect(params.IsMultiTilette).toBe(true);
+		});
+
+		it('converts the deadline to an end-of-day epoch-ms EndTime', () => {
+			const params = toCreateClusterParams(baseForm, TileshareMode.Single, ctx);
+			expect(params.EndTime).toBe(dateTimeToUnix('2026-08-01', '11:59 PM'));
+		});
+
+		it('leaves EndTime undefined when no deadline is provided', () => {
+			const params = toCreateClusterParams(
+				{ ...baseForm, deadline: '' },
+				TileshareMode.Single,
+				ctx
+			);
+			expect(params.EndTime).toBeUndefined();
+		});
+
+		it('wraps a location string into an AddressData object', () => {
+			const params = toCreateClusterParams(
+				{ ...baseForm, location: '123 Main St' },
+				TileshareMode.Single,
+				ctx
+			);
+			expect(params.AddressData).toEqual({
+				Address: '123 Main St',
+				AddressIsVerified: false,
+			});
+		});
+
+		it('omits AddressData when location is empty', () => {
+			const params = toCreateClusterParams(baseForm, TileshareMode.Single, ctx);
+			expect(params.AddressData).toBeUndefined();
+		});
+
+		it('classifies an email recipient into Contacts', () => {
+			const params = toCreateClusterParams(
+				{ ...baseForm, recipients: ['jane@example.com'] },
+				TileshareMode.Single,
+				ctx
+			);
+			expect(params.Contacts).toEqual([{ Email: 'jane@example.com' }]);
+		});
+
+		it('normalizes a bare phone number with the default calling code', () => {
+			const params = toCreateClusterParams(
+				{ ...baseForm, recipients: ['3035551212'] },
+				TileshareMode.Single,
+				ctx
+			);
+			expect(params.Contacts).toEqual([{ PhoneNumber: '+13035551212' }]);
+		});
+
+		it('preserves a phone number that already has a + area code', () => {
+			const params = toCreateClusterParams(
+				{ ...baseForm, recipients: ['+13035551212'] },
+				TileshareMode.Single,
+				ctx
+			);
+			expect(params.Contacts).toEqual([{ PhoneNumber: '+13035551212' }]);
+		});
+
+		it('maps multiple recipients into a mixed Contacts array', () => {
+			const params = toCreateClusterParams(
+				{ ...baseForm, recipients: ['jane@example.com', '3035551212'] },
+				TileshareMode.Single,
+				ctx
+			);
+			expect(params.Contacts).toEqual([
+				{ Email: 'jane@example.com' },
+				{ PhoneNumber: '+13035551212' },
+			]);
+		});
+
+		it('sends an empty Contacts array (never null) when no recipient given', () => {
+			const params = toCreateClusterParams(baseForm, TileshareMode.Single, ctx);
+			expect(params.Contacts).toEqual([]);
+		});
+	});
+
+	describe('createCluster', () => {
+		const createParams = {
+			UserName: 'test@example.com',
+			TimeZone: 'UTC',
+			TimeZoneOffset: 0,
+			Name: 'Finish taxes',
+			IsMultiTilette: false,
+			IncludeMe: true,
+			Contacts: [],
+		};
+
+		it('calls api with params and returns the cluster content on success', async () => {
+			const apiMock = {
+				createCluster: vi.fn().mockResolvedValue({
+					Error: { Code: '0', Message: 'SUCCESS' },
+					Content: mockCluster,
+					ServerStatus: null,
+				}),
+			} as unknown as TileshareApi;
+
+			const service = new TileshareService(apiMock);
+			const result = await service.createCluster(createParams);
+
+			expect(apiMock.createCluster).toHaveBeenCalledWith(createParams);
+			expect(result).toEqual(mockCluster);
+		});
+
+		it('treats a null Error envelope as success', async () => {
+			const apiMock = {
+				createCluster: vi.fn().mockResolvedValue({
+					Error: null,
+					Content: mockCluster,
+					ServerStatus: null,
+				}),
+			} as unknown as TileshareApi;
+
+			const service = new TileshareService(apiMock);
+			await expect(service.createCluster(createParams)).resolves.toEqual(mockCluster);
+		});
+
+		it('throws when the server returns a non-zero error code', async () => {
+			const apiMock = {
+				createCluster: vi.fn().mockResolvedValue({
+					Error: { Code: '500', Message: 'FAILURE' },
+					Content: null,
+					ServerStatus: null,
+				}),
+			} as unknown as TileshareApi;
+
+			const service = new TileshareService(apiMock);
+			await expect(service.createCluster(createParams)).rejects.toThrow();
+		});
+
+		it('propagates network errors', async () => {
+			const apiMock = {
+				createCluster: vi.fn().mockRejectedValue(new Error('Network error')),
+			} as unknown as TileshareApi;
+
+			const service = new TileshareService(apiMock);
+			await expect(service.createCluster(createParams)).rejects.toThrow();
 		});
 	});
 

--- a/src/services/tileshareService.ts
+++ b/src/services/tileshareService.ts
@@ -1,12 +1,19 @@
 import { TileshareApi } from '@/api/tileshareApi';
 import {
 	ClusterPageParams,
+	ContactModel,
+	CreateTileShareClusterParams,
 	DEFAULT_CLUSTER_PAGE_SIZE,
 	DeleteTileShareClusterParams,
 	GetClustersParams,
 	InvitationStatus,
+	TileshareFormState,
+	TileshareMode,
 } from '@/core/common/types/tileshare';
 import { normalizeError } from '@/core/error';
+import { TilerResponseError } from '@/core/common/types/errors';
+import { classifyContact, normalizePhoneNumber } from '@/core/util/contact';
+import { dateTimeToUnix } from '@/core/util/eventTimeConversion';
 
 /**
  * Converts 1-based page params into the server's offset-based query.
@@ -27,6 +34,58 @@ function toClusterQuery(params?: ClusterPageParams): Partial<GetClustersParams> 
 	if (sortOrder !== undefined) query.SortOrder = sortOrder;
 
 	return query;
+}
+
+export type TileshareCreateContext = {
+	userName: string | null;
+	timeZone: string | null;
+	timeZoneOffset: number | null;
+	/** Bare dial code (e.g. "1") prepended to phone numbers lacking a '+' area code. */
+	defaultCallingCode: string;
+};
+
+/** Default task length used until the form collects a real duration. */
+const DEFAULT_TASK_DURATION_MS = 60 * 60 * 1000; // 1h
+
+/**
+ * Routes a raw share-to value to the correct contact channel. The backend does
+ * not auto-detect email vs phone, so we classify client-side and normalize
+ * phone numbers to `+<callingCode><digits>` form.
+ */
+function toContact(value: string, defaultCallingCode: string): ContactModel {
+	const trimmed = value.trim();
+	return classifyContact(trimmed) === 'phone'
+		? { PhoneNumber: normalizePhoneNumber(trimmed, defaultCallingCode) }
+		: { Email: trimmed };
+}
+
+/**
+ * Maps the Create Tileshare form state to the server's TemplateClusterModel
+ * payload: `deadline` -> end-of-day epoch ms `EndTime`, `location` -> AddressData
+ * object, `shareTo` -> Contacts array (never null), `mode` -> IsMultiTilette.
+ */
+export function toCreateClusterParams(
+	form: TileshareFormState,
+	mode: TileshareMode,
+	ctx: TileshareCreateContext
+): CreateTileShareClusterParams {
+	const location = form.location.trim();
+	const note = form.note.trim();
+	const recipients = form.recipients.map((r) => r.trim()).filter(Boolean);
+
+	return {
+		UserName: ctx.userName,
+		TimeZone: ctx.timeZone,
+		TimeZoneOffset: ctx.timeZoneOffset,
+		Name: form.name.trim(),
+		IsMultiTilette: mode === TileshareMode.Multi,
+		IncludeMe: true,
+		EndTime: form.deadline ? dateTimeToUnix(form.deadline, '11:59 PM') : undefined,
+		DurationInMs: DEFAULT_TASK_DURATION_MS,
+		Notes: note || undefined,
+		AddressData: location ? { Address: location, AddressIsVerified: false } : undefined,
+		Contacts: recipients.map((r) => toContact(r, ctx.defaultCallingCode)),
+	};
 }
 
 class TileshareService {
@@ -64,6 +123,20 @@ class TileshareService {
 			return res.Content.designatedTiles;
 		} catch (error) {
 			console.error('Error fetching tileshare inbox', error);
+			throw normalizeError(error);
+		}
+	}
+
+	async createCluster(params: CreateTileShareClusterParams) {
+		try {
+			const res = await this.api.createCluster(params);
+			// Success is a null Error or Code "0"; only a present non-zero code is a failure.
+			if (res.Error && res.Error.Code !== '0') {
+				throw TilerResponseError.fromApiCodeResponse(res.Error);
+			}
+			return res.Content;
+		} catch (error) {
+			console.error('Error creating tileshare cluster', error);
 			throw normalizeError(error);
 		}
 	}


### PR DESCRIPTION
This pull request introduces a new Tileshare creation flow, including UI components and backend integration for creating Tileshare clusters. The main changes are the addition of user interface components for cluster creation and selection, the implementation of the API method for cluster creation, and comprehensive tests for the new API functionality.

**Tileshare Creation Flow Enhancements:**

* Added the `TileshareCreate` component, providing a form UI and logic for creating Tileshare clusters, including validation, notification handling, and success feedback.
* Added the `TileshareCreateSelection` component, a popover menu for selecting between single and multi Tileshare creation modes, with animation and accessibility features.
* Added the `TileshareToolbar` component, which displays a user greeting and a button to trigger the creation selection menu.

**API Integration:**

* Implemented the `createCluster` method in `TileshareApi`, allowing the frontend to send POST requests to the backend to create new clusters.
* Updated API type imports to support the new cluster creation method.

**Testing:**

* Added comprehensive tests for the new `createCluster` method in `tileshareApi`, including request validation and error handling.